### PR TITLE
Fix EOL characters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Files that will always have CRLF line endings on checkout
+*.bat text eol=crlf

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/Gradle.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/Gradle.java
@@ -64,8 +64,8 @@ public class Gradle implements BuildFeature {
 
         generatorContext.addTemplate("gradleWrapperJar", new BinaryTemplate(WRAPPER_JAR, classLoader.getResource(WRAPPER_JAR)));
         generatorContext.addTemplate("gradleWrapperProperties", new URLTemplate(WRAPPER_PROPS, classLoader.getResource(WRAPPER_PROPS)));
-        generatorContext.addTemplate("gradleWrapper", new URLTemplate("gradlew", classLoader.getResource("gradle/gradlew"), true));
-        generatorContext.addTemplate("gradleWrapperBat", new URLTemplate("gradlew.bat", classLoader.getResource("gradle/gradlew.bat"), false));
+        generatorContext.addTemplate("gradleWrapper", new BinaryTemplate("gradlew", classLoader.getResource("gradle/gradlew"), true));
+        generatorContext.addTemplate("gradleWrapperBat", new BinaryTemplate("gradlew.bat", classLoader.getResource("gradle/gradlew.bat"), false));
 
         generatorContext.addBuildPlugin(GradlePlugin.builder().id("eclipse").build());
         generatorContext.addBuildPlugin(GradlePlugin.builder().id("idea").build());

--- a/grails-forge-core/src/main/java/org/grails/forge/template/BinaryTemplate.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/template/BinaryTemplate.java
@@ -23,6 +23,10 @@ public class BinaryTemplate extends URLTemplate {
         super(path, url);
     }
 
+    public BinaryTemplate(String path, URL url, boolean executable) {
+        super(path, url, executable);
+    }
+
     @Override
     public boolean isBinary() {
         return true;


### PR DESCRIPTION
Fixes https://github.com/grails/grails-core/issues/13112

The root cause is that OS-specific "templates" are being "rendered" as _text_, which messes up EOL characters. We need to treat them as _binary_ files to preserve line endings.