### PR TITLE
Removed code generation jetty.version=10.0 in gradle.properties when …

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootJettyFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootJettyFeature.java
@@ -51,7 +51,6 @@ public class SpringBootJettyFeature extends SpringBootEmbeddedServlet {
                 .groupId("org.springframework.boot")
                 .artifactId("spring-boot-starter-jetty")
                 .compile());
-        generatorContext.getBuildProperties().put("jetty.version", "10.0");
     }
 
     @Override


### PR DESCRIPTION
…generating Jetty is selected.