### PR TITLE
Update webdriver-binaries-gradle-plugin to version 3.2

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/Geb.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/Geb.java
@@ -99,6 +99,7 @@ public class Geb implements DefaultFeature {
                     .id("com.github.erdi.webdriver-binaries")
                     .lookupArtifactId("webdriver-binaries-gradle-plugin")
                     .extension(new RockerWritable(webdriverBinariesPlugin.template(generatorContext.getProject(), generatorContext.getOperatingSystem())))
+                            .version("3.2")
                     .build());
 
             generatorContext.addDependency(Dependency.builder()

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>com.github.erdi</groupId>
             <artifactId>webdriver-binaries-gradle-plugin</artifactId>
-            <version>3.0</version>
+            <version>3.2</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/GebSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/GebSpec.groovy
@@ -64,7 +64,7 @@ class GebSpec extends ApplicationContextSpec implements CommandOutputFixture {
         final def settingGradle = output["settings.gradle"]
 
         expect:
-        settingGradle.contains("id \"com.github.erdi.webdriver-binaries\" version \"3.0\"")
+        settingGradle.contains("id \"com.github.erdi.webdriver-binaries\" version \"3.2\"")
         buildGradle.contains("id \"com.github.erdi.webdriver-binaries\"")
         buildGradle.contains("webdriverBinaries")
         buildGradle.contains("chromedriver '110.0.5481.77'")
@@ -79,7 +79,7 @@ class GebSpec extends ApplicationContextSpec implements CommandOutputFixture {
         final def settingGradle = output["settings.gradle"]
 
         expect:
-        settingGradle.contains("id \"com.github.erdi.webdriver-binaries\" version \"3.0\"")
+        settingGradle.contains("id \"com.github.erdi.webdriver-binaries\" version \"3.2\"")
         buildGradle.contains("id \"com.github.erdi.webdriver-binaries\"")
         buildGradle.contains("webdriverBinaries")
         buildGradle.contains("chromedriver '110.0.5481.77'")


### PR DESCRIPTION
When running the automated tests with version 3.0 of the com.github.erdi.webdriver-binaries plugin and jdk 17 the following exception is thrown

```
> Task :configureChromeDriverBinary FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':configureChromeDriverBinary'.
> java.lang.reflect.InvocationTargetException

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

```


With the update to version 3.2 the tests work with jdk 17