### PR TITLE
fix: Set controller scope in config

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/web/GrailsWeb.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/web/GrailsWeb.java
@@ -52,6 +52,7 @@ public class GrailsWeb implements DefaultFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         final Map<String, Object> config = generatorContext.getConfiguration();
+        config.put("grails.controllers.defaultScope", "singleton");
         config.put("grails.views.default.codec", "html");
         generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-web").build());
     }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/web/GrailsWebSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/web/GrailsWebSpec.groovy
@@ -27,6 +27,7 @@ class GrailsWebSpec extends ApplicationContextSpec implements CommandOutputFixtu
 
 
         then:
+        config.grails.controllers.defaultScope == 'singleton'
         config.grails.views.default.codec == 'html'
     }
 }


### PR DESCRIPTION
The default scope of controllers in Grails is 'prototype'. 
This setting should be set to 'singleton' in config of newly created apps (and it was, up to Grails 5).
However, with the introduction of the new Grails-forge for Grails 6, the default scope was no longer automatically set to 'singleton.' This PR adds it back to the config.