### PR TITLE
fix: Change GORM reactor events config

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/GormFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/GormFeature.java
@@ -43,6 +43,8 @@ public abstract class GormFeature implements DefaultFeature {
     }
 
     protected void applyDefaultGormConfig(Map<String, Object> config) {
-        config.put("grails.gorm.reactor.events", isGormReactorEventsEnabled());
+        if (isGormReactorEventsEnabled()) {
+            config.put("grails.events.spring", true);
+        }
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/template/YamlTemplateSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/template/YamlTemplateSpec.groovy
@@ -8,7 +8,7 @@ class YamlTemplateSpec extends Specification {
         Map<String, Object> config = [:]
         config.put("info.app.name", "foo")
         config.put("grails.codegen.defaultPackage", "example")
-        config.put("grails.gorm.reactor.events", false)
+        config.put("grails.events.spring", true)
         config.put("datasources.default.url", "dbURL")
         config.put("datasources.default.className", "h2")
         config.put("jpa.default.properties.hibernate.hbm2ddl", "auto")
@@ -24,9 +24,8 @@ class YamlTemplateSpec extends Specification {
 grails:
   codegen:
     defaultPackage: example
-  gorm:
-    reactor:
-      events: false
+  events:
+    spring: true
 datasources:
   default:
     url: dbURL


### PR DESCRIPTION
Gorm reactor events configuration changed in https://github.com/grails/grails-async/commit/229a888e03842cd82eba790225500992b28aa940. Both the config key and the default from true to false.

That means the grails.gorm.reactor.events config can be removed from application.yml 👍 