### PR TITLE
fix: Change dataSource/hibernate config

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -74,7 +74,7 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
         applyDefaultGormConfig(config);
         config.put("dataSource.pooled", true);
         config.put("dataSource.jmxExport", true);
-        config.put("hibernate.hbm2ddl.auto", "update");
+        config.put("dataSource.dbCreate", "update");
         config.put("hibernate.cache.queries", false);
         config.put("hibernate.cache.use_second_level_cache", false);
         config.put("hibernate.cache.use_query_cache", false);

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -65,7 +65,7 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
         ctx.configuration.containsKey("dataSource.url")
         ctx.configuration.containsKey("dataSource.pooled")
         ctx.configuration.containsKey("dataSource.jmxExport")
-        ctx.configuration.containsKey("hibernate.hbm2ddl.auto")
+        ctx.configuration.containsKey("dataSource.dbCreate")
         ctx.configuration.containsKey("hibernate.cache.queries")
         ctx.configuration.containsKey("hibernate.cache.use_second_level_cache")
         ctx.configuration.containsKey("hibernate.cache.use_query_cache")


### PR DESCRIPTION
The dataSource config in the documentation uses dataSource.dbCreate. Grails Forge creates an application.yml with hibernate.hbm2ddl.auto. These two config settings do the same thing under the hood, which is set hibernate.hbm2ddl.auto. I suggest the application forge uses the documented config setting dataSource.dbCreate.