### PR TITLE
refactor: Move forcing of groovy-xml to buildSrc

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -42,7 +42,6 @@ repositories {
 
 configurations {
     all {
-        resolutionStrategy.force 'org.codehaus.groovy:groovy-xml:3.0.13'
         @if (features.contains("geb")) {
         resolutionStrategy.eachDependency { DependencyResolveDetails details->
             if (details.requested.group == 'org.seleniumhq.selenium') {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -24,8 +24,7 @@ dependencies {
 }
 
 configurations.configureEach {
-    // Needed for Gradle 7.6 (Groovy 3.0.13) compatibility
-    // with Grails Gradle Plugin 6.1.x (Groovy 3.0.11).
+    // Needed for Gradle compatibility with Grails Gradle Plugin.
     // (Only needed when there are files in buildSrc/src/*/groovy)
-    resolutionStrategy.force 'org.codehaus.groovy:groovy-xml:3.0.13'
+    resolutionStrategy.force "org.codehaus.groovy:groovy-xml:${GroovySystem.version}"
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -22,3 +22,10 @@ dependencies {
 }
 }
 }
+
+configurations.configureEach {
+    // Needed for Gradle 7.6 (Groovy 3.0.13) compatibility
+    // with Grails Gradle Plugin 6.1.x (Groovy 3.0.11).
+    // (Only needed when there are files in buildSrc/src/*/groovy)
+    resolutionStrategy.force 'org.codehaus.groovy:groovy-xml:3.0.13'
+}


### PR DESCRIPTION
When using Gradle 7.6 together with the Grails Gradle Plugin and groovy files in src/*/groovy there is a clash between the version bundled with Gradle (3.0.13) and the version loaded by the Grails Gradle Plugin (3.0.11). This forces the version to be compatible with Gradle for compiling groovy files in buildSrc.

This was previously included in the application's build.gradle leading to unnecessary clutter.