### PR TITLE
fix: Remove war config from generated build.gradle

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -94,10 +94,4 @@ tasks.withType(Test) {
 }
 }
 
-@if (features.contains("grails-gsp")) {
-tasks.withType(War).configureEach { War war ->
-    war.dependsOn compileGroovyPages
-}
-}
-
 @gradleBuild.renderExtensions()


### PR DESCRIPTION
This configuration is now done by the grails-gradle-plugin.

Related: grails/grails-gradle-plugin#234