### PR TITLE
fix: Remove forcing of groovy-xml

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -22,9 +22,3 @@ dependencies {
 }
 }
 }
-
-configurations.configureEach {
-    // Needed for Gradle compatibility with Grails Gradle Plugin.
-    // (Only needed when there are files in buildSrc/src/*/groovy)
-    resolutionStrategy.force "org.codehaus.groovy:groovy-xml:${GroovySystem.version}"
-}


### PR DESCRIPTION
This configuration is no longer necessary as the groovy-xml version no longer leaks from the gradle-gradle-plugin (via grails-bootstrap and grails-shell).

Related: grails/grails-gradle-plugin#273