### PR TITLE
fix(deps): Remove dependency org.glassfish.web:el-impl

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -88,10 +88,6 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
                 .artifactId("hibernate5")
                 .compile());
         generatorContext.addDependency(Dependency.builder()
-                .groupId("org.glassfish.web")
-                .lookupArtifactId("el-impl")
-                .runtime());
-        generatorContext.addDependency(Dependency.builder()
                 .groupId("org.apache.tomcat")
                 .artifactId("tomcat-jdbc")
                 .runtime());

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -13,11 +13,6 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.web</groupId>
-            <artifactId>el-impl</artifactId>
-            <version>2.2.1-b05</version>
-        </dependency>
-        <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
             <version>1.18</version>

--- a/grails-forge-core/src/test/groovy/org/grails/forge/build/gradle/GradleSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/build/gradle/GradleSpec.groovy
@@ -60,7 +60,7 @@ class GradleSpec extends ApplicationContextSpec implements CommandOutputFixture 
         settingsGradle.contains("maven { url \"https://repo.grails.org/grails/core/\" }")
         settingsGradle.contains("gradlePluginPortal()")
         settingsGradle.contains("id \"org.grails.grails-web\" version \"6.1.2\"")
-        settingsGradle.contains("id \"org.grails.plugins.views-json\" version \"3.1.1\"")
+        settingsGradle.contains("id \"org.grails.plugins.views-json\" version \"3.1.2\"")
         !settingsGradle.contains("id \"org.grails.grails-gsp\" version \"6.1.2\"")
         !settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.3.0\"")
     }
@@ -77,8 +77,8 @@ class GradleSpec extends ApplicationContextSpec implements CommandOutputFixture 
         settingsGradle.contains("maven { url \"https://repo.grails.org/grails/core/\" }")
         settingsGradle.contains("gradlePluginPortal()")
         settingsGradle.contains("id \"org.grails.grails-web\" version \"6.1.2\"")
-        settingsGradle.contains("id \"org.grails.plugins.views-markup\" version \"3.1.1\"")
-        !settingsGradle.contains("id \"org.grails.plugins.views-json\" version \"3.1.1\"")
+        settingsGradle.contains("id \"org.grails.plugins.views-markup\" version \"3.1.2\"")
+        !settingsGradle.contains("id \"org.grails.plugins.views-json\" version \"3.1.2\"")
         !settingsGradle.contains("id \"org.grails.grails-gsp\" version \"6.1.1\"")
         !settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.3.0\"")
     }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -29,7 +29,6 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
 
         then:
         template.contains('implementation("org.grails.plugins:hibernate5")')
-        template.contains("runtimeOnly(\"org.glassfish.web:el-impl:2.2.1-b05\")")
         template.contains("runtimeOnly(\"org.apache.tomcat:tomcat-jdbc\")")
         template.contains("runtimeOnly(\"com.h2database:h2\")")
     }


### PR DESCRIPTION
There is no need for this dependency.
An el-impl is already provided by Spring Boot/tomcat-embed-el. tomcat-embed-el is also used for other servlet containers.

Related: https://github.com/spring-projects/spring-boot/issues/24744