### PR TITLE
fix(deps): Remove dependency org.hibernate:hibernate-core

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -88,10 +88,6 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
                 .artifactId("hibernate5")
                 .compile());
         generatorContext.addDependency(Dependency.builder()
-                .groupId("org.hibernate")
-                .lookupArtifactId("hibernate-core")
-                .compile());
-        generatorContext.addDependency(Dependency.builder()
                 .groupId("org.glassfish.web")
                 .lookupArtifactId("el-impl")
                 .runtime());

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -13,11 +13,6 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
-            <version>5.6.15.Final</version>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>el-impl</artifactId>
             <version>2.2.1-b05</version>

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -29,7 +29,6 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
 
         then:
         template.contains('implementation("org.grails.plugins:hibernate5")')
-        template.contains('implementation("org.hibernate:hibernate-core:5.6.15.Final")')
         template.contains("runtimeOnly(\"org.glassfish.web:el-impl:2.2.1-b05\")")
         template.contains("runtimeOnly(\"org.apache.tomcat:tomcat-jdbc\")")
         template.contains("runtimeOnly(\"com.h2database:h2\")")


### PR DESCRIPTION
There is no need to include this library as a direct dependency for Grails applications. Any libraries/modules that depend on it declares it themselves.