### PR TITLE
fix(deps): Remove dependency javax.xml.bind:jaxb-api

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -99,10 +99,6 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
                 .groupId("org.apache.tomcat")
                 .artifactId("tomcat-jdbc")
                 .runtime());
-        generatorContext.addDependency(Dependency.builder()
-                .groupId("javax.xml.bind")
-                .lookupArtifactId("jaxb-api")
-                .runtime());
     }
 
     @Override

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -23,11 +23,6 @@
             <version>2.2.1-b05</version>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
             <version>1.18</version>

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -33,7 +33,6 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
         template.contains("runtimeOnly(\"org.glassfish.web:el-impl:2.2.1-b05\")")
         template.contains("runtimeOnly(\"org.apache.tomcat:tomcat-jdbc\")")
         template.contains("runtimeOnly(\"com.h2database:h2\")")
-        template.contains("runtimeOnly(\"javax.xml.bind:jaxb-api:2.3.1\")")
     }
 
     void "test dependencies are present for buildSrc"() {


### PR DESCRIPTION
There is no need to include this library as a direct dependency for Grails applications. Any libraries/modules that depend on it declares it themselves.