### PR TITLE
fix(templates): Remove App profile info

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/templates/index.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/templates/index.rocker.raw
@@ -13,7 +13,6 @@ json {
     environment Environment.current.name
     appversion grailsApplication.metadata.getApplicationVersion()
     grailsversion GrailsUtil.grailsVersion
-    appprofile grailsApplication.config.getProperty('grails.profile')
     groovyversion GroovySystem.getVersion()
     jvmversion System.getProperty('java.version')
     reloadingagentenabled Environment.reloadingAgentEnabled

--- a/grails-forge-core/src/main/resources/gsp/index.gsp
+++ b/grails-forge-core/src/main/resources/gsp/index.gsp
@@ -10,7 +10,6 @@
         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li class="dropdown-item"><a href="#">Environment: ${grails.util.Environment.current.name}</a></li>
-            <li class="dropdown-item"><a href="#">App profile: ${grailsApplication.config.grails?.profile}</a></li>
             <li class="dropdown-item"><a href="#">App version:
                 <g:meta name="info.app.version"/></a>
             </li>


### PR DESCRIPTION
Remove App profile info from starter templates as they where removed in Grails 6.

Resolves #288