### PR TITLE
feat(core): add environments block to datasource configuration

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/config/ConfigurationFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/config/ConfigurationFeature.java
@@ -24,6 +24,11 @@ import java.util.function.Function;
 
 public interface ConfigurationFeature extends OneOfFeature {
 
+    String ENV_KEY = "environments";
+    String DEV_ENV_KEY = "development";
+    String TEST_ENV_KEY = "test";
+    String PROD_ENV_KEY = "production";
+
     @Override
     default Class<?> getFeatureClass() {
         return ConfigurationFeature.class;

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.grails.forge.feature.config.ConfigurationFeature.DEV_ENV_KEY;
+import static org.grails.forge.feature.config.ConfigurationFeature.TEST_ENV_KEY;
+import static org.grails.forge.feature.config.ConfigurationFeature.PROD_ENV_KEY;
 import static org.grails.forge.feature.config.ConfigurationFeature.ENV_KEY;
 
 /**
@@ -36,11 +38,21 @@ public interface DatabaseDriverConfigurationFeature extends Feature {
 
     String getPasswordKey();
 
+    String getDbCreateKey();
+
     default void applyDefaultConfig(DatabaseDriverFeature dbFeature, Map<String, Object> config) {
-        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(ENV_KEY + "." + DEV_ENV_KEY + "." + getUrlKey(), url));
+        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(getUrlKey(), url));
         Optional.ofNullable(dbFeature.getDriverClass()).ifPresent(driver -> config.put(getDriverKey(), driver));
         Optional.ofNullable(dbFeature.getDefaultUser()).ifPresent(user -> config.put(getUsernameKey(), user));
         Optional.ofNullable(dbFeature.getDefaultPassword()).ifPresent(pass -> config.put(getPasswordKey(), pass));
+
+        config.put(ENV_KEY + "." + DEV_ENV_KEY + "." + getDbCreateKey(), "create-drop");
+        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(ENV_KEY + "." + DEV_ENV_KEY + "." + getUrlKey(), url));
+        config.put(ENV_KEY + "." + TEST_ENV_KEY + "." + getDbCreateKey(), "update");
+        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(ENV_KEY + "." + TEST_ENV_KEY + "." + getUrlKey(), url));
+        config.put(ENV_KEY + "." + PROD_ENV_KEY + "." + getDbCreateKey(), "none");
+        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(ENV_KEY + "." + PROD_ENV_KEY + "." + getUrlKey(), url));
+
         final Map<String, Object> additionalConfig = dbFeature.getAdditionalConfig();
         if (!additionalConfig.isEmpty()) {
             config.putAll(additionalConfig);

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
@@ -41,17 +41,16 @@ public interface DatabaseDriverConfigurationFeature extends Feature {
     String getDbCreateKey();
 
     default void applyDefaultConfig(DatabaseDriverFeature dbFeature, Map<String, Object> config) {
-        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(getUrlKey(), url));
         Optional.ofNullable(dbFeature.getDriverClass()).ifPresent(driver -> config.put(getDriverKey(), driver));
         Optional.ofNullable(dbFeature.getDefaultUser()).ifPresent(user -> config.put(getUsernameKey(), user));
         Optional.ofNullable(dbFeature.getDefaultPassword()).ifPresent(pass -> config.put(getPasswordKey(), pass));
 
         config.put(ENV_KEY + "." + DEV_ENV_KEY + "." + getDbCreateKey(), "create-drop");
-        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(ENV_KEY + "." + DEV_ENV_KEY + "." + getUrlKey(), url));
+        Optional.ofNullable(dbFeature.getJdbcDevUrl()).ifPresent(url -> config.put(ENV_KEY + "." + DEV_ENV_KEY + "." + getUrlKey(), url));
         config.put(ENV_KEY + "." + TEST_ENV_KEY + "." + getDbCreateKey(), "update");
-        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(ENV_KEY + "." + TEST_ENV_KEY + "." + getUrlKey(), url));
+        Optional.ofNullable(dbFeature.getJdbcTestUrl()).ifPresent(url -> config.put(ENV_KEY + "." + TEST_ENV_KEY + "." + getUrlKey(), url));
         config.put(ENV_KEY + "." + PROD_ENV_KEY + "." + getDbCreateKey(), "none");
-        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(ENV_KEY + "." + PROD_ENV_KEY + "." + getUrlKey(), url));
+        Optional.ofNullable(dbFeature.getJdbcProdUrl()).ifPresent(url -> config.put(ENV_KEY + "." + PROD_ENV_KEY + "." + getUrlKey(), url));
 
         final Map<String, Object> additionalConfig = dbFeature.getAdditionalConfig();
         if (!additionalConfig.isEmpty()) {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
@@ -20,6 +20,9 @@ import org.grails.forge.feature.Feature;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.grails.forge.feature.config.ConfigurationFeature.DEV_ENV_KEY;
+import static org.grails.forge.feature.config.ConfigurationFeature.ENV_KEY;
+
 /**
  * A feature that configures a datasource with a driver
  */
@@ -34,7 +37,7 @@ public interface DatabaseDriverConfigurationFeature extends Feature {
     String getPasswordKey();
 
     default void applyDefaultConfig(DatabaseDriverFeature dbFeature, Map<String, Object> config) {
-        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(getUrlKey(), url));
+        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(ENV_KEY + "." + DEV_ENV_KEY + "." + getUrlKey(), url));
         Optional.ofNullable(dbFeature.getDriverClass()).ifPresent(driver -> config.put(getDriverKey(), driver));
         Optional.ofNullable(dbFeature.getDefaultUser()).ifPresent(user -> config.put(getUsernameKey(), user));
         Optional.ofNullable(dbFeature.getDefaultPassword()).ifPresent(pass -> config.put(getPasswordKey(), pass));

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
@@ -65,7 +65,16 @@ public abstract class DatabaseDriverFeature implements OneOfFeature {
 
     public abstract boolean embedded();
 
-    public abstract String getJdbcUrl();
+    @Deprecated()
+    public String getJdbcUrl() {
+        return getJdbcProdUrl();
+    }
+
+    public abstract String getJdbcDevUrl();
+
+    public abstract String getJdbcTestUrl();
+
+    public abstract String getJdbcProdUrl();
 
     public abstract String getDriverClass();
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/H2.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/H2.java
@@ -40,8 +40,18 @@ public class H2 extends DatabaseDriverFeature {
     }
 
     @Override
-    public String getJdbcUrl() {
+    public String getJdbcDevUrl() {
         return "jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE";
+    }
+
+    @Override
+    public String getJdbcTestUrl() {
+        return "jdbc:h2:mem:testDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE";
+    }
+
+    @Override
+    public String getJdbcProdUrl() {
+        return "jdbc:h2:./prodDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE";
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -37,6 +37,7 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
     private static final String DRIVER_KEY = PREFIX + "driverClassName";
     private static final String USERNAME_KEY = PREFIX + "username";
     private static final String PASSWORD_KEY = PREFIX + "password";
+    private static final String DB_CREATE_KEY = PREFIX + "dbCreate";
 
     private final DatabaseDriverFeature defaultDbFeature;
 
@@ -123,6 +124,11 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
     @Override
     public String getPasswordKey() {
         return PASSWORD_KEY;
+    }
+
+    @Override
+    public String getDbCreateKey() {
+        return DB_CREATE_KEY;
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/MySQL.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/MySQL.java
@@ -44,7 +44,17 @@ public class MySQL extends DatabaseDriverFeature {
     }
 
     @Override
-    public String getJdbcUrl() {
+    public String getJdbcDevUrl() {
+        return "jdbc:mysql://localhost:3306/devDb";
+    }
+
+    @Override
+    public String getJdbcTestUrl() {
+        return "jdbc:mysql://localhost:3306/testDb";
+    }
+
+    @Override
+    public String getJdbcProdUrl() {
         return "jdbc:mysql://localhost:3306/db";
     }
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/PostgreSQL.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/PostgreSQL.java
@@ -44,7 +44,17 @@ public class PostgreSQL extends DatabaseDriverFeature {
     }
 
     @Override
-    public String getJdbcUrl() {
+    public String getJdbcDevUrl() {
+        return "jdbc:postgresql://localhost:5432/devDb";
+    }
+
+    @Override
+    public String getJdbcTestUrl() {
+        return "jdbc:postgresql://localhost:5432/testDb";
+    }
+
+    @Override
+    public String getJdbcProdUrl() {
         // postgres docker image uses default db name and username of postgres so we use the same
         return "jdbc:postgresql://localhost:5432/postgres";
     }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/SQLServer.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/SQLServer.java
@@ -44,7 +44,17 @@ public class SQLServer extends DatabaseDriverFeature {
     }
 
     @Override
-    public String getJdbcUrl() {
+    public String getJdbcDevUrl() {
+        return "jdbc:sqlserver://localhost:1433;databaseName=devDb";
+    }
+
+    @Override
+    public String getJdbcTestUrl() {
+        return "jdbc:sqlserver://localhost:1433;databaseName=testDb";
+    }
+
+    @Override
+    public String getJdbcProdUrl() {
         return "jdbc:sqlserver://localhost:1433;databaseName=tempdb";
     }
 

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -63,7 +63,7 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
         GeneratorContext ctx = buildGeneratorContext(['gorm-hibernate5'])
 
         then:
-        ctx.configuration.containsKey("dataSource.url")
+//        ctx.configuration.containsKey("dataSource.url")
         ctx.configuration.containsKey("dataSource.pooled")
         ctx.configuration.containsKey("dataSource.jmxExport")
         ctx.configuration.containsKey("dataSource.dbCreate")
@@ -84,7 +84,7 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
         config.environments.test.dataSource.dbCreate == 'update'
         config.environments.production.dataSource.dbCreate == 'none'
         config.environments.development.dataSource.url == 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
-        config.environments.test.dataSource.url == 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
-        config.environments.production.dataSource.url == 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
+        config.environments.test.dataSource.url == 'jdbc:h2:mem:testDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
+        config.environments.production.dataSource.url == 'jdbc:h2:./prodDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -1,5 +1,6 @@
 package org.grails.forge.feature.database
 
+import groovy.yaml.YamlSlurper
 import org.grails.forge.ApplicationContextSpec
 import org.grails.forge.BuildBuilder
 import org.grails.forge.application.ApplicationType
@@ -69,5 +70,16 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
         ctx.configuration.containsKey("hibernate.cache.queries")
         ctx.configuration.containsKey("hibernate.cache.use_second_level_cache")
         ctx.configuration.containsKey("hibernate.cache.use_query_cache")
+    }
+
+    void "test match values of datasource config"() {
+
+        when:
+        final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
+        final String applicationYaml = output["grails-app/conf/application.yml"]
+        def config = new YamlSlurper().parseText(applicationYaml)
+
+        then:
+        config.environments.development.dataSource.url == 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -80,6 +80,11 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
         def config = new YamlSlurper().parseText(applicationYaml)
 
         then:
+        config.environments.development.dataSource.dbCreate == 'create-drop'
+        config.environments.test.dataSource.dbCreate == 'update'
+        config.environments.production.dataSource.dbCreate == 'none'
         config.environments.development.dataSource.url == 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
+        config.environments.test.dataSource.url == 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
+        config.environments.production.dataSource.url == 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MySQLSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MySQLSpec.groovy
@@ -30,9 +30,11 @@ class MySQLSpec extends ApplicationContextSpec {
         GeneratorContext ctx = buildGeneratorContext(["gorm-hibernate5", "mysql"])
 
         then:
-        ctx.getConfiguration().get("dataSource.url") == 'jdbc:mysql://localhost:3306/db'
         ctx.getConfiguration().get("dataSource.driverClassName") == 'com.mysql.cj.jdbc.Driver'
         ctx.getConfiguration().get("dataSource.username") == 'root'
         ctx.getConfiguration().get("dataSource.password") == ''
+        ctx.getConfiguration().get("environments.development.dataSource.url") == 'jdbc:mysql://localhost:3306/devDb'
+        ctx.getConfiguration().get("environments.test.dataSource.url") == 'jdbc:mysql://localhost:3306/testDb'
+        ctx.getConfiguration().get("environments.production.dataSource.url") == 'jdbc:mysql://localhost:3306/db'
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/PostgresSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/PostgresSpec.groovy
@@ -30,9 +30,11 @@ class PostgresSpec extends ApplicationContextSpec {
         GeneratorContext ctx = buildGeneratorContext(["gorm-hibernate5", "postgres"])
 
         then:
-        ctx.getConfiguration().get("dataSource.url") == 'jdbc:postgresql://localhost:5432/postgres'
         ctx.getConfiguration().get("dataSource.driverClassName") == 'org.postgresql.Driver'
         ctx.getConfiguration().get("dataSource.username") == 'postgres'
         ctx.getConfiguration().get("dataSource.password") == ''
+        ctx.getConfiguration().get("environments.development.dataSource.url") == 'jdbc:postgresql://localhost:5432/devDb'
+        ctx.getConfiguration().get("environments.test.dataSource.url") == 'jdbc:postgresql://localhost:5432/testDb'
+        ctx.getConfiguration().get("environments.production.dataSource.url") == 'jdbc:postgresql://localhost:5432/postgres'
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/SQLServerSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/SQLServerSpec.groovy
@@ -29,11 +29,13 @@ class SQLServerSpec extends ApplicationContextSpec {
         when:
         GeneratorContext ctx = buildGeneratorContext(["gorm-hibernate5", "sqlserver"])
 
-        then:
-        ctx.getConfiguration().get("dataSource.url") == 'jdbc:sqlserver://localhost:1433;databaseName=tempdb'
         ctx.getConfiguration().get("dataSource.driverClassName") == 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
         ctx.getConfiguration().get("dataSource.username") == 'sa'
         ctx.getConfiguration().get("dataSource.password") == ''
+        then:
+        ctx.getConfiguration().get("environments.development.dataSource.url") == 'jdbc:sqlserver://localhost:1433;databaseName=devDb'
+        ctx.getConfiguration().get("environments.test.dataSource.url") == 'jdbc:sqlserver://localhost:1433;databaseName=testDb'
+        ctx.getConfiguration().get("environments.production.dataSource.url") == 'jdbc:sqlserver://localhost:1433;databaseName=tempdb'
     }
 
 }


### PR DESCRIPTION
This will add datasource config for each environments (development, test, and production).

Fixes grails/grails-forge#373