### PR TITLE
fix(deps): Revert upgrade to asset-pipeline 4.4.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,12 +13,6 @@
         "^org\\.seleniumhq\\.selenium"
       ],
       "groupName": "selenium monorepo"
-    },
-    {
-      "matchPackagePatterns": [
-        "^com\\.bertramlabs\\.plugins:asset-pipeline.*"
-      ],
-      "groupName": "asset-pipeline"
     }
   ]
 }

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -120,12 +120,12 @@
         <dependency>
             <groupId>com.bertramlabs.plugins</groupId>
             <artifactId>asset-pipeline-grails</artifactId>
-            <version>4.4.0</version>
+            <version>4.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.bertramlabs.plugins</groupId>
             <artifactId>asset-pipeline-gradle</artifactId>
-            <version>4.4.0</version>
+            <version>4.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/grails-forge-core/src/test/groovy/org/grails/forge/build/gradle/GradleSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/build/gradle/GradleSpec.groovy
@@ -45,7 +45,7 @@ class GradleSpec extends ApplicationContextSpec implements CommandOutputFixture 
         settingsGradle.contains("gradlePluginPortal()")
         settingsGradle.contains("id \"org.grails.grails-web\" version \"6.1.2\"")
         settingsGradle.contains("id \"org.grails.grails-gsp\" version \"6.1.2\"")
-        settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.4.0\"")
+        settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.3.0\"")
     }
 
     void "test settings.gradle for REST-API"() {
@@ -62,7 +62,7 @@ class GradleSpec extends ApplicationContextSpec implements CommandOutputFixture 
         settingsGradle.contains("id \"org.grails.grails-web\" version \"6.1.2\"")
         settingsGradle.contains("id \"org.grails.plugins.views-json\" version \"3.1.2\"")
         !settingsGradle.contains("id \"org.grails.grails-gsp\" version \"6.1.2\"")
-        !settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.4.0\"")
+        !settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.3.0\"")
     }
 
     void "test settings.gradle for REST-API for markup-views"() {
@@ -79,7 +79,7 @@ class GradleSpec extends ApplicationContextSpec implements CommandOutputFixture 
         settingsGradle.contains("id \"org.grails.grails-web\" version \"6.1.2\"")
         settingsGradle.contains("id \"org.grails.plugins.views-markup\" version \"3.1.2\"")
         !settingsGradle.contains("id \"org.grails.plugins.views-json\" version \"3.1.2\"")
-        !settingsGradle.contains("id \"org.grails.grails-gsp\" version \"6.1.1\"")
-        !settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.4.0\"")
+        !settingsGradle.contains("id \"org.grails.grails-gsp\" version \"6.1.2\"")
+        !settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.3.0\"")
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
@@ -27,7 +27,7 @@ class AssetPipelineSpec extends ApplicationContextSpec implements CommandOutputF
 
         expect:
         buildSrcBuildGradle != null
-        buildSrcBuildGradle.contains("implementation(\"com.bertramlabs.plugins:asset-pipeline-gradle:4.4.0\")")
+        buildSrcBuildGradle.contains("implementation(\"com.bertramlabs.plugins:asset-pipeline-gradle:4.3.0\")")
 
     }
 
@@ -40,7 +40,7 @@ class AssetPipelineSpec extends ApplicationContextSpec implements CommandOutputF
 
         then:
         template.contains("id \"com.bertramlabs.asset-pipeline\"")
-        template.contains("runtimeOnly(\"com.bertramlabs.plugins:asset-pipeline-grails:4.4.0\")")
+        template.contains("runtimeOnly(\"com.bertramlabs.plugins:asset-pipeline-grails:4.3.0\")")
         template.contains('''
 assets {
     minifyJs = true


### PR DESCRIPTION
There is no asset-pipeline-grails 4.4.0 release.
4.4.0 is a release for Spring Boot 3 and Micronaut 4.