### PR TITLE
fix: Remove failing iedriverserver

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/template/webdriverBinariesPlugin.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/template/webdriverBinariesPlugin.rocker.raw
@@ -6,8 +6,5 @@
 webdriverBinaries {
     chromedriver '122.0.6260.0'
     geckodriver '0.33.0'
-@if (os == OperatingSystem.WINDOWS) {
-    iedriverserver '3.141.59'
-}
     edgedriver '110.0.1587.57'
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/GebSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/GebSpec.groovy
@@ -84,7 +84,6 @@ class GebSpec extends ApplicationContextSpec implements CommandOutputFixture {
         buildGradle.contains("webdriverBinaries")
         buildGradle.contains("chromedriver '122.0.6260.0'")
         buildGradle.contains("geckodriver '0.33.0'")
-        buildGradle.contains("iedriverserver '3.141.59'")
         buildGradle.contains("edgedriver '110.0.1587.57'")
     }
 }


### PR DESCRIPTION
When generating an app of type 'Web Application' on a Windows system the build fails to load with the error:
`Could not find method iedriverserver() for arguments [3.141.59] on extension 'webdriverBinaries' of type com.github.erdi.gradle.webdriver.WebDriverBinariesPluginExtension.`

This commit removes `iedriverserver` from the webdriverBinaries block.

Closes #348