### PR TITLE
Change http to https in grails-forge\grails-forge-core\src\main\resou…

### DIFF
--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.grails.forge.features</groupId>
     <artifactId>grails-forge-features</artifactId>


### PR DESCRIPTION
…rces\pom.xml

from checkstyle
http:// URLs are not allowed but got 'http://maven.apache.org/xsd/maven-4.0.0.xsd'. Use https:// instead.