### PR TITLE
Adjust change on IOFeatureUtil.java to fix build of grails-forge-core on Java 11

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/util/IOFeatureUtil.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/util/IOFeatureUtil.java
@@ -50,7 +50,8 @@ public class IOFeatureUtil {
         } else {
             final String jarPath = path.toString().substring(0, sep);
             if (jarPath.endsWith(JAR_EXTENSION)) {
-                try (FileSystem zipFs = FileSystems.newFileSystem(Paths.get(URI.create(jarPath)), null)) {
+                ClassLoader loader = null;
+                try (FileSystem zipFs = FileSystems.newFileSystem(Paths.get(URI.create(jarPath)), loader)) {
                     walkFiles(zipFs.getPath(path.toString().substring(sep + 1)), classLoader, addTemplate);
                 }
             }

--- a/grails-forge-core/src/main/java/org/grails/forge/util/IOFeatureUtil.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/util/IOFeatureUtil.java
@@ -50,7 +50,7 @@ public class IOFeatureUtil {
         } else {
             final String jarPath = path.toString().substring(0, sep);
             if (jarPath.endsWith(JAR_EXTENSION)) {
-                try (FileSystem zipFs = FileSystems.newFileSystem(Paths.get(URI.create(jarPath)))) {
+                try (FileSystem zipFs = FileSystems.newFileSystem(Paths.get(URI.create(jarPath)), null)) {
                     walkFiles(zipFs.getPath(path.toString().substring(sep + 1)), classLoader, addTemplate);
                 }
             }


### PR DESCRIPTION
Adjust part of prior change to grails-forge-core/src/main/java/org/grails/forge/util/IOFeatureUtil.java

https://github.com/grails/grails-forge/commit/ebccdcd3e7986f6edc6003171c924113aaaf5ee9#diff-e386809d9d5b4947af804c22ff787f87a14064ebd60dd485332c3457b141b7eb

@matrei This change was necessary for me to build grails-forge-core on java 11.  