### PR TITLE
Add support for grails environments in logback xml config using spring boot extensions

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/FeatureContext.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/FeatureContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/FeatureContext.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/FeatureContext.java
@@ -77,7 +77,9 @@ public class FeatureContext {
         return features.stream().filter(feature -> {
             for (FeaturePredicate predicate: exclusions) {
                 if (predicate.test(feature)) {
-                    predicate.getWarning().ifPresent(message -> { throw new IllegalArgumentException(message); });
+                    predicate.getWarning().ifPresent(message -> {
+                        throw new IllegalArgumentException(message);
+                    });
                     return false;
                 }
             }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/logging/Logback.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/logging/Logback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/logging/Logback.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/logging/Logback.java
@@ -60,10 +60,15 @@ public class Logback implements LoggingFeature, DefaultFeature {
     public void apply(GeneratorContext generatorContext) {
         OperatingSystem operatingSystem = generatorContext.getOperatingSystem();
         boolean jansi = false;
+
         if (operatingSystem != OperatingSystem.WINDOWS) {
             jansi = true;
         }
-        generatorContext.addTemplate("loggingConfig", new RockerTemplate("grails-app/conf/logback.xml", logback.template(jansi)));
+
+        String projectName = generatorContext.getProject().getName();
+        String packageName = generatorContext.getProject().getPackageName();
+
+        generatorContext.addTemplate("loggingConfig", new RockerTemplate("grails-app/conf/logback-spring.xml", logback.template(projectName, packageName, jansi)));
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("grails-logging")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/logging/template/logback.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/logging/template/logback.rocker.raw
@@ -1,21 +1,41 @@
-@args (boolean jansi)
+@args (String projectName, String packageName, boolean jansi)
 
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
-
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <withJansi>@jansi</withJansi>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${CONSOLE_LOG_THRESHOLD}</level>
+        </filter>
         <encoder>
-            <charset>UTF-8</charset>
-            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>${CONSOLE_LOG_CHARSET}</charset>
         </encoder>
     </appender>
 
-    <root level="error">
-        <appender-ref ref="STDOUT" />
+    <root level="ERROR">
+        <appender-ref ref="CONSOLE"/>
     </root>
 
+    <springProfile name="development">
+        <logger name="StackTrace" level="ERROR" additivity="false" />
+
+<!--        <logger name="@packageName" level="DEBUG"/>-->
+
+<!--        <logger name="org.hibernate.SQL" level="DEBUG"/>-->
+<!--        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE"/>-->
+<!--        <logger name="org.springframework.security" level="TRACE"/>-->
+
+<!--        <root level="WARN"/>-->
+    </springProfile>
+
+<!--    logging to a file-->
+<!--    <property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}/}spring.log}"/>-->
+<!--    <include resource="org/springframework/boot/logging/logback/file-appender.xml" />-->
+<!--    <root level="ERROR">-->
+<!--        <appender-ref ref="FILE" />-->
+<!--    </root>-->
+<!--    add logging.file.name to application.yml-->
 </configuration>

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/logging/LogbackSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/logging/LogbackSpec.groovy
@@ -23,12 +23,12 @@ class LogbackSpec extends ApplicationContextSpec implements CommandOutputFixture
     }
 
     @Unroll
-    void "test logback.xml config file is present for #applicationType application"() {
+    void "test logback-spring.xml config file is present for #applicationType application"() {
         when:
         def output = generate(applicationType, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
 
         then:
-        output.containsKey("grails-app/conf/logback.xml")
+        output.containsKey("grails-app/conf/logback-spring.xml")
 
         where:
         applicationType << ApplicationType.values().toList()


### PR DESCRIPTION
Transition logback xml config to use spring logback extensions which supports environment specific configuration

Close to old logback.groovy configuration, except it writes everything to console by default, which matches Spring Boot 2.

`logback.xml` becomes `logback-spring.xml`

https://docs.spring.io/spring-boot/docs/2.7.18/reference/html/howto.html#howto.logging.logback

https://docs.spring.io/spring-boot/docs/2.7.18/reference/html/features.html#features.logging.logback-extensions