### PR TITLE
ci: Use Java 11 in 6.2.x branch

### DIFF
--- a/.github/workflows/mavenCentral.yml
+++ b/.github/workflows/mavenCentral.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
       - name: "🔐 Generate secring file"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
       - name: "🔢 Set the current release version"
@@ -128,7 +128,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
       - name: "✅ Run Tests"
@@ -186,7 +186,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
       - name: "✅ Run Tests"
@@ -235,7 +235,7 @@ jobs:
       - name: "☕️ Setup GraalVM CE"
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'graalvm-community'
           native-image-musl: 'true'
           components: 'native-image'
@@ -280,7 +280,7 @@ jobs:
       - name: "☕️ Setup GraalVM CE"
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -324,7 +324,7 @@ jobs:
       - name: "☕️ Setup GraalVM CE"
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -368,7 +368,7 @@ jobs:
       - name: "☕️ Setup GraalVM CE"
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -419,7 +419,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
       - name: "🚀 Grails SDK Minor Release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,9 +236,9 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: '11'
-          distribution: 'graalvm-community'
           native-image-musl: 'true'
           components: 'native-image'
+          version: '22.3.3'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
@@ -281,8 +281,8 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: '11'
-          distribution: 'graalvm-community'
           components: 'native-image'
+          version: '22.3.3'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
@@ -325,8 +325,8 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: '11'
-          distribution: 'graalvm-community'
           components: 'native-image'
+          version: '22.3.3'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
@@ -369,8 +369,8 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: '11'
-          distribution: 'graalvm-community'
           components: 'native-image'
+          version: '22.3.3'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/sdkman.yml
+++ b/.github/workflows/sdkman.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
       - name: "🚀 Grails SDK Minor Release"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -156,8 +156,8 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: '11'
-          distribution: 'graalvm-community'
           components: 'native-image'
+          version: '22.3.3'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
@@ -192,8 +192,8 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: '11'
-          distribution: 'graalvm-community'
           components: 'native-image'
+          version: '22.3.3'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
@@ -230,8 +230,8 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: '11'
-          distribution: 'graalvm-community'
           components: 'native-image'
+          version: '22.3.3'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
@@ -266,8 +266,8 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: '11'
-          distribution: 'graalvm-community'
           components: 'native-image'
+          version: '22.3.3'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -218,6 +218,7 @@ jobs:
           name: grails-darwin-amd64-snapshot
           path: grails-darwin-amd64-snapshot.zip
   macos-arm:
+    if: false # Graalvm cannot build Java 11 OS X Arm Native Image
     name: "Build OS X Arm Native CLI"
     runs-on: macos-latest
     env:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
       - name: "🔨 Run Build"
@@ -62,7 +62,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
       - name: "✅ Run Tests"
@@ -118,7 +118,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
       - name: "✅ Run Tests"
@@ -155,7 +155,7 @@ jobs:
       - name: "☕️ Setup GraalVM CE"
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -191,7 +191,7 @@ jobs:
       - name: "☕️ Setup GraalVM CE"
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -229,7 +229,7 @@ jobs:
       - name: "☕️ Setup GraalVM CE"
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -265,7 +265,7 @@ jobs:
       - name: "☕️ Setup GraalVM CE"
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
If native image is built with Java 17, applications created with it will not be compatible with Java 11.

```console
> Task :bootRun FAILED
Error: LinkageError occurred while loading main class g621app.Application
        java.lang.UnsupportedClassVersionError: g621app/Application has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```