### PR TITLE
Set profile on all applications and add grails.codegen.defaultPackage

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grailsProfiles/GrailsProfiles.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grailsProfiles/GrailsProfiles.java
@@ -25,6 +25,7 @@ import org.grails.forge.feature.DefaultFeature;
 import org.grails.forge.feature.Feature;
 import org.grails.forge.options.Options;
 
+import java.util.Map;
 import java.util.Set;
 
 @Singleton
@@ -51,6 +52,11 @@ public class GrailsProfiles implements DefaultFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
+
+
+        final Map<String, Object> config = generatorContext.getConfiguration();
+        // Required by profile commands when package is not set
+        config.put("grails.codegen.defaultPackage", generatorContext.getProject().getPackageName());
 
         ApplicationType applicationType = generatorContext.getApplicationType();
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grailsProfiles/GrailsProfiles.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grailsProfiles/GrailsProfiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grailsProfiles/GrailsProfiles.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grailsProfiles/GrailsProfiles.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.forge.feature.grailsProfiles;
+
+import jakarta.inject.Singleton;
+import org.grails.forge.application.ApplicationType;
+import org.grails.forge.application.generator.GeneratorContext;
+import org.grails.forge.build.dependencies.Dependency;
+import org.grails.forge.build.dependencies.Scope;
+import org.grails.forge.feature.Category;
+import org.grails.forge.feature.DefaultFeature;
+import org.grails.forge.feature.Feature;
+import org.grails.forge.options.Options;
+
+import java.util.Set;
+
+@Singleton
+public class GrailsProfiles implements DefaultFeature {
+    @Override
+    public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "grails-profiles";
+    }
+
+    @Override
+    public boolean isVisible() {
+        return false;
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+
+        ApplicationType applicationType = generatorContext.getApplicationType();
+
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("org.grails.profiles")
+                .artifactId(applicationType.getName().replace("_", "-"))
+                .scope(Scope.PROFILE));
+    }
+
+    @Override
+    public String getCategory() {
+        return Category.CONFIGURATION;
+    }
+}

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grailsProfiles/GrailsProfiles.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grailsProfiles/GrailsProfiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grailsWrapper/GrailsWrapper.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grailsWrapper/GrailsWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grailsWrapper/GrailsWrapper.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grailsWrapper/GrailsWrapper.java
@@ -19,8 +19,6 @@ import jakarta.inject.Singleton;
 import org.grails.forge.application.ApplicationType;
 import org.grails.forge.application.OperatingSystem;
 import org.grails.forge.application.generator.GeneratorContext;
-import org.grails.forge.build.dependencies.Dependency;
-import org.grails.forge.build.dependencies.Scope;
 import org.grails.forge.template.BinaryTemplate;
 
 @Singleton
@@ -55,13 +53,6 @@ public class GrailsWrapper implements GrailsWrapperFeature {
         generatorContext.addTemplate("grailsWrapperJar", new BinaryTemplate("grails-wrapper.jar", classLoader.getResource("grails-wrapper/grails-wrapper.jar")));
         generatorContext.addTemplate("grailsWrapper", new BinaryTemplate("grailsw", classLoader.getResource("grails-wrapper/grailsw"), true));
         generatorContext.addTemplate("grailsWrapperBat", new BinaryTemplate("grailsw.bat", classLoader.getResource("grails-wrapper/grailsw.bat"), false));
-
-        ApplicationType applicationType = generatorContext.getApplicationType();
-
-        generatorContext.addDependency(Dependency.builder()
-                .groupId("org.grails.profiles")
-                .artifactId(applicationType.getName())
-                .scope(Scope.PROFILE));
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grailsWrapper/GrailsWrapper.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grailsWrapper/GrailsWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grailsProfiles/GrailsProfilesSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grailsProfiles/GrailsProfilesSpec.groovy
@@ -1,7 +1,8 @@
-package org.grails.forge.feature.grailsProfiles.grailsWrapper
+package org.grails.forge.feature.grailsProfiles
 
 import org.grails.forge.ApplicationContextSpec
 import org.grails.forge.application.ApplicationType
+import org.grails.forge.application.generator.GeneratorContext
 import org.grails.forge.fixture.CommandOutputFixture
 import org.grails.forge.options.JdkVersion
 import org.grails.forge.options.Options
@@ -19,6 +20,19 @@ class GrailsProfilesSpec extends ApplicationContextSpec implements CommandOutput
         output.containsKey("build.gradle")
         def build = output.get("build.gradle")
         build.contains("profile(\"org.grails.profiles:${applicationType.name.replace("_", "-")}\")")
+
+        where:
+        applicationType << ApplicationType.values().toList()
+    }
+
+    void "test config"() {
+        when:
+        def output = generate(applicationType, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
+
+        then:
+        output.containsKey("grails-app/conf/application.yml")
+        def build = output.get("grails-app/conf/application.yml")
+        build.contains("defaultPackage")
 
         where:
         applicationType << ApplicationType.values().toList()

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grailsProfiles/grailsWrapper/GrailsProfilesSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grailsProfiles/grailsWrapper/GrailsProfilesSpec.groovy
@@ -1,0 +1,26 @@
+package org.grails.forge.feature.grailsProfiles.grailsWrapper
+
+import org.grails.forge.ApplicationContextSpec
+import org.grails.forge.application.ApplicationType
+import org.grails.forge.fixture.CommandOutputFixture
+import org.grails.forge.options.JdkVersion
+import org.grails.forge.options.Options
+import org.grails.forge.options.TestFramework
+import spock.lang.Unroll
+
+class GrailsProfilesSpec extends ApplicationContextSpec implements CommandOutputFixture {
+
+    @Unroll
+    void "test profile dependency is present for #applicationType application"() {
+        when:
+        def output = generate(applicationType, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
+
+        then:
+        output.containsKey("build.gradle")
+        def build = output.get("build.gradle")
+        build.contains("profile(\"org.grails.profiles:${applicationType.name.replace("_", "-")}\")")
+
+        where:
+        applicationType << ApplicationType.values().toList()
+    }
+}

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grailsWrapper/GrailsWrapperSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grailsWrapper/GrailsWrapperSpec.groovy
@@ -23,18 +23,4 @@ class GrailsWrapperSpec extends ApplicationContextSpec implements CommandOutputF
         where:
         applicationType << ApplicationType.values().toList()
     }
-
-    @Unroll
-    void "test profile dependency is present for #applicationType application"() {
-        when:
-        def output = generate(applicationType, new Options(TestFramework.SPOCK, JdkVersion.JDK_11), ['grails-wrapper'])
-
-        then:
-        output.containsKey("build.gradle")
-        def build = output.get("build.gradle")
-        build.contains("profile(\"org.grails.profiles:$applicationType.name\")")
-
-        where:
-        applicationType << ApplicationType.values().toList()
-    }
 }


### PR DESCRIPTION
grails-shell requires a profile to run

profiles are mapped 1:1 to the 4 forge application types

profile were being added by the GrailsWrapper feature and they have now been moved over to a new DefaultFeature, GrailsProfiles.

Also adds `grails.codegen.defaultPackage` to `application.yml` which is required by some profile commands