### PR TITLE
feat(core): include development, test and production dataSource configuration

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/config/ConfigurationFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/config/ConfigurationFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,12 @@ import org.grails.forge.template.Template;
 import java.util.function.Function;
 
 public interface ConfigurationFeature extends OneOfFeature {
+
+    final String ENVIRONMENTS_KEY = "environments";
+    final String DEV_ENVIRONMENT_KEY = "development";
+    final String TEST_ENVIRONMENT_KEY = "test";
+    final String PROD_ENVIRONMENT_KEY = "production";
+    final String PROPERTIES_KEY = "properties";
 
     @Override
     default Class<?> getFeatureClass() {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/config/ConfigurationFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/config/ConfigurationFeature.java
@@ -24,11 +24,11 @@ import java.util.function.Function;
 
 public interface ConfigurationFeature extends OneOfFeature {
 
-    final String ENVIRONMENTS_KEY = "environments";
-    final String DEV_ENVIRONMENT_KEY = "development";
-    final String TEST_ENVIRONMENT_KEY = "test";
-    final String PROD_ENVIRONMENT_KEY = "production";
-    final String PROPERTIES_KEY = "properties";
+    String ENVIRONMENTS_KEY = "environments";
+    String DEV_ENVIRONMENT_KEY = "development";
+    String TEST_ENVIRONMENT_KEY = "test";
+    String PROD_ENVIRONMENT_KEY = "production";
+    String PROPERTIES_KEY = "properties";
 
     @Override
     default Class<?> getFeatureClass() {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
@@ -54,23 +54,23 @@ public interface DatabaseDriverConfigurationFeature extends Feature {
         config.put(ENVIRONMENTS_KEY + "." + PROD_ENVIRONMENT_KEY + "." + getDbCreateKey(), "none");
         Optional.ofNullable(dbFeature.getJdbcProdUrl()).ifPresent(url -> config.put(ENVIRONMENTS_KEY + "." + PROD_ENVIRONMENT_KEY + "." + getUrlKey(), url));
 
-        addProductionDataSourceProperties(config,"jmxEnabled", true);
-        addProductionDataSourceProperties(config,"initialSize", 5);
-        addProductionDataSourceProperties(config,"maxActive", 50);
-        addProductionDataSourceProperties(config,"minIdle", 5);
-        addProductionDataSourceProperties(config,"maxIdle", 25);
-        addProductionDataSourceProperties(config,"maxWait", 10000);
-        addProductionDataSourceProperties(config,"maxAge", 600000);
-        addProductionDataSourceProperties(config,"timeBetweenEvictionRunsMillis", 5000);
-        addProductionDataSourceProperties(config,"minEvictableIdleTimeMillis", 60000);
-        addProductionDataSourceProperties(config,"validationQuery", "SELECT 1");
-        addProductionDataSourceProperties(config,"validationQueryTimeout", 3);
-        addProductionDataSourceProperties(config,"validationInterval", 15000);
-        addProductionDataSourceProperties(config,"testOnBorrow", true);
-        addProductionDataSourceProperties(config,"testWhileIdle", true);
-        addProductionDataSourceProperties(config,"testOnReturn", false);
-        addProductionDataSourceProperties(config,"jdbcInterceptors", "ConnectionState");
-        addProductionDataSourceProperties(config,"defaultTransactionIsolation", 2);
+        addProductionDataSourceProperties(config, "jmxEnabled", true);
+        addProductionDataSourceProperties(config, "initialSize", 5);
+        addProductionDataSourceProperties(config, "maxActive", 50);
+        addProductionDataSourceProperties(config, "minIdle", 5);
+        addProductionDataSourceProperties(config, "maxIdle", 25);
+        addProductionDataSourceProperties(config, "maxWait", 10000);
+        addProductionDataSourceProperties(config, "maxAge", 600000);
+        addProductionDataSourceProperties(config, "timeBetweenEvictionRunsMillis", 5000);
+        addProductionDataSourceProperties(config, "minEvictableIdleTimeMillis", 60000);
+        addProductionDataSourceProperties(config, "validationQuery", "SELECT 1");
+        addProductionDataSourceProperties(config, "validationQueryTimeout", 3);
+        addProductionDataSourceProperties(config, "validationInterval", 15000);
+        addProductionDataSourceProperties(config, "testOnBorrow", true);
+        addProductionDataSourceProperties(config, "testWhileIdle", true);
+        addProductionDataSourceProperties(config, "testOnReturn", false);
+        addProductionDataSourceProperties(config, "jdbcInterceptors", "ConnectionState");
+        addProductionDataSourceProperties(config, "defaultTransactionIsolation", 2);
 
         final Map<String, Object> additionalConfig = dbFeature.getAdditionalConfig();
         if (!additionalConfig.isEmpty()) {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,13 @@ import org.grails.forge.feature.Feature;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.grails.forge.feature.config.ConfigurationFeature.DEV_ENVIRONMENT_KEY;
+import static org.grails.forge.feature.config.ConfigurationFeature.TEST_ENVIRONMENT_KEY;
+import static org.grails.forge.feature.config.ConfigurationFeature.PROD_ENVIRONMENT_KEY;
+import static org.grails.forge.feature.config.ConfigurationFeature.ENVIRONMENTS_KEY;
+import static org.grails.forge.feature.config.ConfigurationFeature.PROPERTIES_KEY;
+import static org.grails.forge.feature.database.HibernateGorm.PREFIX;
+
 /**
  * A feature that configures a datasource with a driver
  */
@@ -33,14 +40,45 @@ public interface DatabaseDriverConfigurationFeature extends Feature {
 
     String getPasswordKey();
 
+    String getDbCreateKey();
+
     default void applyDefaultConfig(DatabaseDriverFeature dbFeature, Map<String, Object> config) {
-        Optional.ofNullable(dbFeature.getJdbcUrl()).ifPresent(url -> config.put(getUrlKey(), url));
         Optional.ofNullable(dbFeature.getDriverClass()).ifPresent(driver -> config.put(getDriverKey(), driver));
         Optional.ofNullable(dbFeature.getDefaultUser()).ifPresent(user -> config.put(getUsernameKey(), user));
         Optional.ofNullable(dbFeature.getDefaultPassword()).ifPresent(pass -> config.put(getPasswordKey(), pass));
+
+        config.put(ENVIRONMENTS_KEY + "." + DEV_ENVIRONMENT_KEY + "." + getDbCreateKey(), "create-drop");
+        Optional.ofNullable(dbFeature.getJdbcDevUrl()).ifPresent(url -> config.put(ENVIRONMENTS_KEY + "." + DEV_ENVIRONMENT_KEY + "." + getUrlKey(), url));
+        config.put(ENVIRONMENTS_KEY + "." + TEST_ENVIRONMENT_KEY + "." + getDbCreateKey(), "update");
+        Optional.ofNullable(dbFeature.getJdbcTestUrl()).ifPresent(url -> config.put(ENVIRONMENTS_KEY + "." + TEST_ENVIRONMENT_KEY + "." + getUrlKey(), url));
+        config.put(ENVIRONMENTS_KEY + "." + PROD_ENVIRONMENT_KEY + "." + getDbCreateKey(), "none");
+        Optional.ofNullable(dbFeature.getJdbcProdUrl()).ifPresent(url -> config.put(ENVIRONMENTS_KEY + "." + PROD_ENVIRONMENT_KEY + "." + getUrlKey(), url));
+
+        addProductionDataSourceProperties(config,"jmxEnabled", true);
+        addProductionDataSourceProperties(config,"initialSize", 5);
+        addProductionDataSourceProperties(config,"maxActive", 50);
+        addProductionDataSourceProperties(config,"minIdle", 5);
+        addProductionDataSourceProperties(config,"maxIdle", 25);
+        addProductionDataSourceProperties(config,"maxWait", 10000);
+        addProductionDataSourceProperties(config,"maxAge", 600000);
+        addProductionDataSourceProperties(config,"timeBetweenEvictionRunsMillis", 5000);
+        addProductionDataSourceProperties(config,"minEvictableIdleTimeMillis", 60000);
+        addProductionDataSourceProperties(config,"validationQuery", "SELECT 1");
+        addProductionDataSourceProperties(config,"validationQueryTimeout", 3);
+        addProductionDataSourceProperties(config,"validationInterval", 15000);
+        addProductionDataSourceProperties(config,"testOnBorrow", true);
+        addProductionDataSourceProperties(config,"testWhileIdle", true);
+        addProductionDataSourceProperties(config,"testOnReturn", false);
+        addProductionDataSourceProperties(config,"jdbcInterceptors", "ConnectionState");
+        addProductionDataSourceProperties(config,"defaultTransactionIsolation", 2);
+
         final Map<String, Object> additionalConfig = dbFeature.getAdditionalConfig();
         if (!additionalConfig.isEmpty()) {
             config.putAll(additionalConfig);
         }
+    }
+
+    default void addProductionDataSourceProperties(Map<String, Object> config, String key, Object value) {
+        config.put(ENVIRONMENTS_KEY + "." + PROD_ENVIRONMENT_KEY + "." + PREFIX + PROPERTIES_KEY + "." + key, value);
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,16 @@ public abstract class DatabaseDriverFeature implements OneOfFeature {
 
     public abstract boolean embedded();
 
-    public abstract String getJdbcUrl();
+    @Deprecated()
+    public String getJdbcUrl() {
+        return getJdbcProdUrl();
+    }
+
+    public abstract String getJdbcDevUrl();
+
+    public abstract String getJdbcTestUrl();
+
+    public abstract String getJdbcProdUrl();
 
     public abstract String getDriverClass();
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
@@ -65,7 +65,7 @@ public abstract class DatabaseDriverFeature implements OneOfFeature {
 
     public abstract boolean embedded();
 
-    @Deprecated()
+    @Deprecated(since = "6.2.2", forRemoval = true)
     public String getJdbcUrl() {
         return getJdbcProdUrl();
     }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/H2.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/H2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,18 @@ public class H2 extends DatabaseDriverFeature {
     }
 
     @Override
-    public String getJdbcUrl() {
+    public String getJdbcDevUrl() {
         return "jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE";
+    }
+
+    @Override
+    public String getJdbcTestUrl() {
+        return "jdbc:h2:mem:testDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE";
+    }
+
+    @Override
+    public String getJdbcProdUrl() {
+        return "jdbc:h2:./prodDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE";
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,12 @@ import java.util.Set;
 @Singleton
 public class HibernateGorm extends GormFeature implements DatabaseDriverConfigurationFeature {
 
-    private static final String PREFIX = "dataSource.";
+    static final String PREFIX = "dataSource.";
     private static final String URL_KEY = PREFIX + "url";
     private static final String DRIVER_KEY = PREFIX + "driverClassName";
     private static final String USERNAME_KEY = PREFIX + "username";
     private static final String PASSWORD_KEY = PREFIX + "password";
+    private static final String DB_CREATE_KEY = PREFIX + "dbCreate";
 
     private final DatabaseDriverFeature defaultDbFeature;
 
@@ -74,7 +75,6 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
         applyDefaultGormConfig(config);
         config.put("dataSource.pooled", true);
         config.put("dataSource.jmxExport", true);
-        config.put("dataSource.dbCreate", "update");
         config.put("hibernate.cache.queries", false);
         config.put("hibernate.cache.use_second_level_cache", false);
         config.put("hibernate.cache.use_query_cache", false);
@@ -111,6 +111,11 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
     @Override
     public String getPasswordKey() {
         return PASSWORD_KEY;
+    }
+
+    @Override
+    public String getDbCreateKey() {
+        return DB_CREATE_KEY;
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/MySQL.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/MySQL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,18 @@ public class MySQL extends DatabaseDriverFeature {
     }
 
     @Override
-    public String getJdbcUrl() {
-        return "jdbc:mysql://localhost:3306/db";
+    public String getJdbcDevUrl() {
+        return "jdbc:mysql://localhost:3306/devDb";
+    }
+
+    @Override
+    public String getJdbcTestUrl() {
+        return "jdbc:mysql://localhost:3306/testDb";
+    }
+
+    @Override
+    public String getJdbcProdUrl() {
+        return "jdbc:mysql://localhost:3306/prodDb";
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/PostgreSQL.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/PostgreSQL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,17 @@ public class PostgreSQL extends DatabaseDriverFeature {
     }
 
     @Override
-    public String getJdbcUrl() {
+    public String getJdbcDevUrl() {
+        return "jdbc:postgresql://localhost:5432/devDb";
+    }
+
+    @Override
+    public String getJdbcTestUrl() {
+        return "jdbc:postgresql://localhost:5432/testDb";
+    }
+
+    @Override
+    public String getJdbcProdUrl() {
         // postgres docker image uses default db name and username of postgres so we use the same
         return "jdbc:postgresql://localhost:5432/postgres";
     }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/SQLServer.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/SQLServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,18 @@ public class SQLServer extends DatabaseDriverFeature {
     }
 
     @Override
-    public String getJdbcUrl() {
-        return "jdbc:sqlserver://localhost:1433;databaseName=tempdb";
+    public String getJdbcDevUrl() {
+        return "jdbc:sqlserver://localhost:1433;databaseName=devDb";
+    }
+
+    @Override
+    public String getJdbcTestUrl() {
+        return "jdbc:sqlserver://localhost:1433;databaseName=testDb";
+    }
+
+    @Override
+    public String getJdbcProdUrl() {
+        return "jdbc:sqlserver://localhost:1433;databaseName=prodDb";
     }
 
     @Override

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -1,5 +1,6 @@
 package org.grails.forge.feature.database
 
+import groovy.yaml.YamlSlurper
 import org.grails.forge.ApplicationContextSpec
 import org.grails.forge.BuildBuilder
 import org.grails.forge.application.ApplicationType
@@ -59,12 +60,44 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
         GeneratorContext ctx = buildGeneratorContext(['gorm-hibernate5'])
 
         then:
-        ctx.configuration.containsKey("dataSource.url")
         ctx.configuration.containsKey("dataSource.pooled")
         ctx.configuration.containsKey("dataSource.jmxExport")
-        ctx.configuration.containsKey("dataSource.dbCreate")
         ctx.configuration.containsKey("hibernate.cache.queries")
         ctx.configuration.containsKey("hibernate.cache.use_second_level_cache")
         ctx.configuration.containsKey("hibernate.cache.use_query_cache")
+    }
+
+    void "test match values of datasource config"() {
+
+        when:
+        final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
+        final String applicationYaml = output["grails-app/conf/application.yml"]
+        def config = new YamlSlurper().parseText(applicationYaml)
+
+        then:
+        config.environments.development.dataSource.dbCreate == 'create-drop'
+        config.environments.test.dataSource.dbCreate == 'update'
+        config.environments.production.dataSource.dbCreate == 'none'
+        config.environments.development.dataSource.url == 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
+        config.environments.test.dataSource.url == 'jdbc:h2:mem:testDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
+        config.environments.production.dataSource.url == 'jdbc:h2:./prodDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
+
+        config.environments.production.dataSource.properties.jmxEnabled == true
+        config.environments.production.dataSource.properties.initialSize == 5
+        config.environments.production.dataSource.properties.maxActive == 50
+        config.environments.production.dataSource.properties.minIdle == 5
+        config.environments.production.dataSource.properties.maxIdle == 25
+        config.environments.production.dataSource.properties.maxWait == 10000
+        config.environments.production.dataSource.properties.maxAge == 600000
+        config.environments.production.dataSource.properties.timeBetweenEvictionRunsMillis == 5000
+        config.environments.production.dataSource.properties.minEvictableIdleTimeMillis == 60000
+        config.environments.production.dataSource.properties.validationQuery == "SELECT 1"
+        config.environments.production.dataSource.properties.validationQueryTimeout == 3
+        config.environments.production.dataSource.properties.validationInterval == 15000
+        config.environments.production.dataSource.properties.testOnBorrow == true
+        config.environments.production.dataSource.properties.testWhileIdle == true
+        config.environments.production.dataSource.properties.testOnReturn == false
+        config.environments.production.dataSource.properties.jdbcInterceptors == "ConnectionState"
+        config.environments.production.dataSource.properties.defaultTransactionIsolation == 2
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MySQLSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MySQLSpec.groovy
@@ -30,9 +30,11 @@ class MySQLSpec extends ApplicationContextSpec {
         GeneratorContext ctx = buildGeneratorContext(["gorm-hibernate5", "mysql"])
 
         then:
-        ctx.getConfiguration().get("dataSource.url") == 'jdbc:mysql://localhost:3306/db'
         ctx.getConfiguration().get("dataSource.driverClassName") == 'com.mysql.cj.jdbc.Driver'
         ctx.getConfiguration().get("dataSource.username") == 'root'
         ctx.getConfiguration().get("dataSource.password") == ''
+        ctx.getConfiguration().get("environments.development.dataSource.url") == 'jdbc:mysql://localhost:3306/devDb'
+        ctx.getConfiguration().get("environments.test.dataSource.url") == 'jdbc:mysql://localhost:3306/testDb'
+        ctx.getConfiguration().get("environments.production.dataSource.url") == 'jdbc:mysql://localhost:3306/prodDb'
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/PostgresSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/PostgresSpec.groovy
@@ -30,9 +30,11 @@ class PostgresSpec extends ApplicationContextSpec {
         GeneratorContext ctx = buildGeneratorContext(["gorm-hibernate5", "postgres"])
 
         then:
-        ctx.getConfiguration().get("dataSource.url") == 'jdbc:postgresql://localhost:5432/postgres'
         ctx.getConfiguration().get("dataSource.driverClassName") == 'org.postgresql.Driver'
         ctx.getConfiguration().get("dataSource.username") == 'postgres'
         ctx.getConfiguration().get("dataSource.password") == ''
+        ctx.getConfiguration().get("environments.development.dataSource.url") == 'jdbc:postgresql://localhost:5432/devDb'
+        ctx.getConfiguration().get("environments.test.dataSource.url") == 'jdbc:postgresql://localhost:5432/testDb'
+        ctx.getConfiguration().get("environments.production.dataSource.url") == 'jdbc:postgresql://localhost:5432/postgres'
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/SQLServerSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/SQLServerSpec.groovy
@@ -30,10 +30,12 @@ class SQLServerSpec extends ApplicationContextSpec {
         GeneratorContext ctx = buildGeneratorContext(["gorm-hibernate5", "sqlserver"])
 
         then:
-        ctx.getConfiguration().get("dataSource.url") == 'jdbc:sqlserver://localhost:1433;databaseName=tempdb'
         ctx.getConfiguration().get("dataSource.driverClassName") == 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
         ctx.getConfiguration().get("dataSource.username") == 'sa'
         ctx.getConfiguration().get("dataSource.password") == ''
+        ctx.getConfiguration().get("environments.development.dataSource.url") == 'jdbc:sqlserver://localhost:1433;databaseName=devDb'
+        ctx.getConfiguration().get("environments.test.dataSource.url") == 'jdbc:sqlserver://localhost:1433;databaseName=testDb'
+        ctx.getConfiguration().get("environments.production.dataSource.url") == 'jdbc:sqlserver://localhost:1433;databaseName=prodDb'
     }
 
 }


### PR DESCRIPTION
Include development, test and production dataSource configuration in generated application.yml

Normally this would be part of a minor release, but given that it was lost between 5.3.x and 6.0.0 it is more of a fix than a feature.

The goal is to match the configuration from Grails 5.3.6:

```
dataSource:
  driverClassName: org.h2.Driver
  username: sa
  password: ''
  pooled: true
  jmxExport: true
environments:
  development:
    dataSource:
      dbCreate: create-drop
      url: jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
  test:
    dataSource:
      dbCreate: update
      url: jdbc:h2:mem:testDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
  production:
    dataSource:
      dbCreate: none
      url: jdbc:h2:./prodDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
      properties:
        jmxEnabled: true
        initialSize: 5
        maxActive: 50
        minIdle: 5
        maxIdle: 25
        maxWait: 10000
        maxAge: 600000
        timeBetweenEvictionRunsMillis: 5000
        minEvictableIdleTimeMillis: 60000
        validationQuery: SELECT 1
        validationQueryTimeout: 3
        validationInterval: 15000
        testOnBorrow: true
        testWhileIdle: true
        testOnReturn: false
        jdbcInterceptors: ConnectionState
        defaultTransactionIsolation: 2
```
