### PR TITLE
build: Make spotless also handle single year in license header

### DIFF
--- a/config/spotless.license.java
+++ b/config/spotless.license.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-$YEAR original authors
+ * Copyright $YEAR original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grailsProfiles/GrailsProfiles.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grailsProfiles/GrailsProfiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grailsWrapper/GrailsWrapper.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grailsWrapper/GrailsWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- This will handle both single year and ranges. https://github.com/diffplug/spotless/tree/main/plugin-gradle#license-header
- Change license header to single year for new files `GrailsWrapper` and `GrailsProfiles`.