### PR TITLE
fix(deps): adjust dependencies required for grails 7

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
@@ -74,6 +74,11 @@ public class AssetPipeline implements DefaultFeature {
                 .lookupArtifactId("asset-pipeline-grails")
                 .runtime());
 
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("org.graalvm.sdk")
+                .lookupArtifactId("graal-sdk")
+                .runtime());
+
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         generatorContext.addTemplate("advancedgrails_svg", new URLTemplate("grails-app/assets/images/advancedgrails.svg", classLoader.getResource("assets/images/advancedgrails.svg")));
         generatorContext.addTemplate("apple-touch-icon_png", new URLTemplate("grails-app/assets/images/apple-touch-icon.png", classLoader.getResource("assets/images/apple-touch-icon.png")));

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
@@ -60,10 +60,6 @@ public class AssetPipeline implements DefaultFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addBuildscriptDependency(Dependency.builder()
-                .groupId("com.bertramlabs.plugins")
-                .lookupArtifactId("asset-pipeline-gradle")
-                .buildscript());
         generatorContext.addBuildPlugin(GradlePlugin.builder()
                 .id("com.bertramlabs.asset-pipeline")
                 .extension(new RockerWritable(assetPipelineExtension.template(generatorContext.getApplicationType())))
@@ -72,11 +68,6 @@ public class AssetPipeline implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("com.bertramlabs.plugins")
                 .lookupArtifactId("asset-pipeline-grails")
-                .runtime());
-
-        generatorContext.addDependency(Dependency.builder()
-                .groupId("org.graalvm.sdk")
-                .lookupArtifactId("graal-sdk")
                 .runtime());
 
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -38,6 +38,7 @@ apply from: "gradle/asciidoc.gradle"
 repositories {
     mavenCentral()
     maven { url "https://repo.grails.org/grails/core/" }
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 
 configurations {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -63,7 +63,9 @@ application {
 }
 
 java {
-    sourceCompatibility = JavaVersion.toVersion("@features.getTargetJdk()")
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(@features.getTargetJdk())
+    }
 }
 
 @if (features.contains("jrebel")) {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -19,13 +19,18 @@ GradleBuild gradleBuild
 )
 
 @seleniumVersion => { @coordinateResolver.apply("selenium-api").getVersion() }
+@assetPipelineVersion => { @coordinateResolver.apply("asset-pipeline-grails").getVersion() }
 
 @for (String importLine : gradleBuild.getPluginsImports()) {
 @(importLine)
 }
 plugins {
 @for (GradlePlugin gradlePlugin : gradleBuild.getPlugins()) {
-    id "@gradlePlugin.getId()"
+    @if(gradlePlugin.getId() == "com.bertramlabs.asset-pipeline") {
+        id "com.bertramlabs.asset-pipeline" version "@assetPipelineVersion"
+    } else {
+        id "@gradlePlugin.getId()"
+    }
 }
 }
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/settingsGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/settingsGradle.rocker.raw
@@ -37,9 +37,6 @@ pluginManagement {
         @if(features.contains("views-markup"))  {
         id "org.grails.plugins.views-markup" version "@viewsGradlePluginVersion"
         }
-        @if(features.contains("asset-pipeline-grails")) {
-        id "com.bertramlabs.asset-pipeline" version "@assetPipelineVersion"
-        }
 
     @for (GradlePlugin gradlePlugin : gradleBuild.getPluginsWithVersion()) {
         id "@gradlePlugin.getId()" version "@gradlePlugin.getVersion()"

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
@@ -103,6 +103,11 @@ public class GrailsGsp implements DefaultFeature {
                 .compile());
         generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-gsp").build());
 
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("org.sitemesh")
+                .lookupArtifactId("grails-plugin-sitemesh3")
+                .compile());
+
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         generatorContext.addTemplate("mainLayout", new URLTemplate(getViewFolderPath() + "layouts/main.gsp", classLoader.getResource("gsp/main.gsp")));
         generatorContext.addTemplate("index", new URLTemplate(getViewFolderPath() + "index.gsp", classLoader.getResource("gsp/index.gsp")));

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -133,6 +133,11 @@
             <version>5.0.1</version>
         </dependency>
         <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <version>22.0.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.11.1</version>
@@ -146,6 +151,11 @@
             <groupId>io.micronaut.serde</groupId>
             <artifactId>micronaut-serde-jackson</artifactId>
             <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.sitemesh</groupId>
+            <artifactId>grails-plugin-sitemesh3</artifactId>
+            <version>7.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -133,11 +133,6 @@
             <version>5.0.1</version>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>graal-sdk</artifactId>
-            <version>22.0.0.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.11.1</version>

--- a/grails-forge-core/src/test/groovy/org/grails/forge/build/gradle/GradleSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/build/gradle/GradleSpec.groovy
@@ -45,7 +45,6 @@ class GradleSpec extends ApplicationContextSpec implements CommandOutputFixture 
         settingsGradle.contains("gradlePluginPortal()")
         settingsGradle.contains("id \"org.grails.grails-web\" version \"7.0.0-SNAPSHOT\"")
         settingsGradle.contains("id \"org.grails.grails-gsp\" version \"7.0.0-SNAPSHOT\"")
-        settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"5.0.1\"")
     }
 
     void "test settings.gradle for REST-API"() {
@@ -62,7 +61,6 @@ class GradleSpec extends ApplicationContextSpec implements CommandOutputFixture 
         settingsGradle.contains("id \"org.grails.grails-web\" version \"7.0.0-SNAPSHOT\"")
         settingsGradle.contains("id \"org.grails.plugins.views-json\" version \"4.0.0-SNAPSHOT\"")
         !settingsGradle.contains("id \"org.grails.grails-gsp\" version \"7.0.0-SNAPSHOT\"")
-        !settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"5.0.1\"")
     }
 
     void "test settings.gradle for REST-API for markup-views"() {
@@ -80,6 +78,5 @@ class GradleSpec extends ApplicationContextSpec implements CommandOutputFixture 
         settingsGradle.contains("id \"org.grails.plugins.views-markup\" version \"4.0.0-SNAPSHOT\"")
         !settingsGradle.contains("id \"org.grails.plugins.views-json\" version \"4.0.0-SNAPSHOT\"")
         !settingsGradle.contains("id \"org.grails.grails-gsp\" version \"7.0.0-SNAPSHOT\"")
-        !settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"5.0.1\"")
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
@@ -41,6 +41,7 @@ class AssetPipelineSpec extends ApplicationContextSpec implements CommandOutputF
         then:
         template.contains("id \"com.bertramlabs.asset-pipeline\"")
         template.contains("runtimeOnly(\"com.bertramlabs.plugins:asset-pipeline-grails:5.0.1\")")
+        template.contains("runtimeOnly(\"org.graalvm.sdk:graal-sdk:22.0.0.2\")")
         template.contains('''
 assets {
     minifyJs = true

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
@@ -20,18 +20,6 @@ class AssetPipelineSpec extends ApplicationContextSpec implements CommandOutputF
         features.contains("asset-pipeline-grails")
     }
 
-    void "test buildSrc is present for buildscript dependencies"() {
-        given:
-        final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
-        final def buildSrcBuildGradle = output["buildSrc/build.gradle"]
-
-        expect:
-        buildSrcBuildGradle != null
-        buildSrcBuildGradle.contains("implementation(\"com.bertramlabs.plugins:asset-pipeline-gradle:5.0.1\")")
-
-    }
-
-
     void "test dependencies are present for gradle"() {
         when:
         final String template = new BuildBuilder(beanContext)
@@ -41,7 +29,6 @@ class AssetPipelineSpec extends ApplicationContextSpec implements CommandOutputF
         then:
         template.contains("id \"com.bertramlabs.asset-pipeline\"")
         template.contains("runtimeOnly(\"com.bertramlabs.plugins:asset-pipeline-grails:5.0.1\")")
-        template.contains("runtimeOnly(\"org.graalvm.sdk:graal-sdk:22.0.0.2\")")
         template.contains('''
 assets {
     minifyJs = true

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
@@ -33,6 +33,7 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
         template.contains("id \"org.grails.grails-web\"")
         template.contains("id \"org.grails.grails-gsp\"")
         template.contains("implementation(\"org.grails.plugins:gsp\")")
+        template.contains("implementation(\"org.sitemesh:grails-plugin-sitemesh3:7.0.0-SNAPSHOT\")")
     }
 
     void "test gsp configuration"() {
@@ -90,6 +91,7 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
         build.contains('id "org.grails.grails-web"')
         build.contains('id "org.grails.grails-gsp"')
         build.contains("implementation(\"org.grails.plugins:gsp\")")
+        build.contains("implementation(\"org.sitemesh:grails-plugin-sitemesh3:7.0.0-SNAPSHOT\")")
 
         where:
         applicationType << [ApplicationType.WEB, ApplicationType.WEB_PLUGIN]
@@ -104,6 +106,7 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
         then:
         !build.contains('id "org.grails.grails-gsp"')
         !build.contains("implementation(\"org.grails.plugins:gsp\")")
+        !build.contains("implementation(\"org.sitemesh:grails-plugin-sitemesh3:7.0.0-SNAPSHOT\")")
 
         where:
         applicationType << [ApplicationType.PLUGIN, ApplicationType.REST_API]


### PR DESCRIPTION
These changes are currently required to start a grails 7 web project.

The `graal-sdk` dependency will be handled as follows:  https://github.com/bertramdev/asset-pipeline/pull/352#issuecomment-2407459979

After removing the asset-pipeline Gradle plugin from `buildSrc/build.gradle` and `setting.gradle` and defining it in one location `build.gradle`, the `graal-sdk` dependency is no longer needed.

```
plugins {
     id "com.bertramlabs.asset-pipeline" version "5.0.1"
}
```

The larger consolidation of buildSrc, settings.gradle and build.gradle will occur on https://github.com/grails/grails-forge/issues/347

