### PR TITLE
Back to Gradle 8.10.2, except when using geb-with-webdriver-binaries

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Scope.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Scope.java
@@ -39,7 +39,6 @@ public class Scope {
     public static final Scope PROFILE = new Scope(Source.MAIN, Collections.singletonList(Phase.PROFILE));
     public static final Scope INTEGRATION_TEST_IMPLEMENTATION_TEST_FIXTURES = new Scope(Source.MAIN, Collections.singletonList(Phase.INTEGRATION_TEST_IMPLEMENTATION_TEST_FIXTURES));
 
-
     @NonNull
     private Source source;
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/Gradle.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/Gradle.java
@@ -31,11 +31,11 @@ import org.grails.forge.feature.build.gradle.templates.buildGradle;
 import org.grails.forge.feature.build.gradle.templates.buildSrcBuildGradle;
 import org.grails.forge.feature.build.gradle.templates.gradleProperties;
 import org.grails.forge.feature.build.gradle.templates.settingsGradle;
+import org.grails.forge.feature.build.gradle.templates.gradleWrapperProperties;
 import org.grails.forge.options.BuildTool;
 import org.grails.forge.options.Options;
 import org.grails.forge.template.BinaryTemplate;
 import org.grails.forge.template.RockerTemplate;
-import org.grails.forge.template.URLTemplate;
 
 import java.util.Set;
 import java.util.function.Function;
@@ -63,7 +63,6 @@ public class Gradle implements BuildFeature {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
         generatorContext.addTemplate("gradleWrapperJar", new BinaryTemplate(WRAPPER_JAR, classLoader.getResource(WRAPPER_JAR)));
-        generatorContext.addTemplate("gradleWrapperProperties", new URLTemplate(WRAPPER_PROPS, classLoader.getResource(WRAPPER_PROPS)));
         generatorContext.addTemplate("gradleWrapper", new BinaryTemplate("gradlew", classLoader.getResource("gradle/gradlew"), true));
         generatorContext.addTemplate("gradleWrapperBat", new BinaryTemplate("gradlew.bat", classLoader.getResource("gradle/gradlew.bat"), false));
 
@@ -96,6 +95,8 @@ public class Gradle implements BuildFeature {
         generatorContext.addTemplate("projectProperties", new RockerTemplate("gradle.properties", gradleProperties.template(generatorContext.getBuildProperties().getProperties())));
         String settingsFile = "settings.gradle";
         generatorContext.addTemplate("gradleSettings", new RockerTemplate(settingsFile, settingsGradle.template(generatorContext.getProject(), build, coordinateResolver, generatorContext.getFeatures())));
+
+        generatorContext.addTemplate("gradleWrapperProperties", new RockerTemplate(WRAPPER_PROPS, gradleWrapperProperties.template(generatorContext.getProject(), build, coordinateResolver, generatorContext.getFeatures())));
     }
 
     private void configureDefaultGradleProps(GeneratorContext generatorContext) {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -9,6 +9,7 @@
 @import org.grails.forge.feature.Features
 @import org.grails.forge.options.TestFramework
 @import org.grails.forge.util.VersionInfo
+@import org.grails.forge.options.JdkVersion
 
 @args (
 ApplicationType applicationType,
@@ -55,7 +56,14 @@ application {
 
 }
 
+@if(features.contains("geb-with-webdriver-binaries")) {
+// geb-with-webdriver-binaries is limited to Gradle 8.6 with max JDK 21
+compileJava.options.release = @JdkVersion.valueOf(Math.min(features.javaVersion().majorVersion(), JdkVersion.JDK_21.majorVersion())).majorVersion()
+
+} else {
 compileJava.options.release = @features.getTargetJdk()
+
+}
 
 @if (features.contains("jrebel")) {
 run {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
@@ -1,0 +1,26 @@
+@import java.util.function.Function
+@import org.grails.forge.application.Project
+@import org.grails.forge.build.dependencies.CoordinateResolver
+@import org.grails.forge.build.dependencies.Coordinate
+@import org.grails.forge.build.gradle.GradleBuild
+@import org.grails.forge.build.gradle.GradlePlugin
+@import org.grails.forge.feature.Features
+
+@args (
+Project project,
+GradleBuild gradleBuild,
+Function<String, Coordinate> coordinateResolver,
+Features features)
+
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+@if(features.contains("geb-with-webdriver-binaries")) {
+# geb-with-webdriver-binaries is limited to Gradle 8.6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+} else {
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+}
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/grails-forge-core/src/main/resources/gradle/wrapper/gradle-wrapper.properties
+++ b/grails-forge-core/src/main/resources/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
-networkTimeout=10000
-validateDistributionUrl=true
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists


### PR DESCRIPTION
geb-with-webdriver-binaries is limited to Gradle 8.6 and JDK 21 max

https://github.com/erdi/webdriver-binaries-gradle-plugin/pull/44

