### PR TITLE
Simplify generated build

### DIFF
--- a/grails-cli/src/test/groovy/org/grails/forge/cli/CommandSpec.groovy
+++ b/grails-cli/src/test/groovy/org/grails/forge/cli/CommandSpec.groovy
@@ -47,7 +47,7 @@ class CommandSpec extends Specification {
     Process executeGradleCommand(String command) {
         StringBuilder gradleCommand = new StringBuilder()
         if (spock.util.environment.OperatingSystem.current.isWindows()) {
-            gradleCommand.append("gradlew.bat")
+            gradleCommand.append("cmd /c gradlew.bat")
         } else {
             gradleCommand.append("./gradlew")
         }

--- a/grails-forge-core/src/main/java/org/grails/forge/application/generator/GeneratorContext.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/application/generator/GeneratorContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.grails.forge.build.BuildProperties;
 import org.grails.forge.build.dependencies.*;
 import org.grails.forge.feature.Feature;
 import org.grails.forge.feature.Features;
+import org.grails.forge.feature.build.gradle.GradleBuildSrc;
 import org.grails.forge.feature.config.ApplicationConfiguration;
 import org.grails.forge.feature.config.BootstrapConfiguration;
 import org.grails.forge.feature.config.Configuration;
@@ -318,9 +319,19 @@ public class GeneratorContext implements DependencyContext {
         if (dependency.requiresLookup()) {
             Coordinate coordinate = coordinateResolver.resolve(dependency.getArtifactId())
                     .orElseThrow(() -> new LookupFailedException(dependency.getArtifactId()));
-            this.buildscriptDependencies.add(dependency.resolved(coordinate));
+            addBuildscriptDependencyBasedOnFeatures(dependency.resolved(coordinate));
         } else {
+            addBuildscriptDependencyBasedOnFeatures(dependency);
+        }
+    }
+
+    private void addBuildscriptDependencyBasedOnFeatures(@NonNull Dependency dependency) {
+        if (getFeature(GradleBuildSrc.class).isPresent()) {
+            // for buildSrc/build.gradle with initial scope
             this.buildscriptDependencies.add(dependency);
+        } else {
+            // for main build.gradle with classpath scope
+            this.buildscriptDependencies.add(dependency.scope(Scope.CLASSPATH));
         }
     }
 

--- a/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Dependency.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Dependency.java
@@ -183,8 +183,8 @@ public final class Dependency {
             return scope(Scope.BUILD);
         }
 
-        public Builder compile() {
-            return scope(Scope.COMPILE);
+        public Builder implementation() {
+            return scope(Scope.IMPLEMENTATION);
         }
 
         public Builder console() {

--- a/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Dependency.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Dependency.java
@@ -119,6 +119,19 @@ public final class Dependency {
                 coordinate.isPom());
     }
 
+    public Dependency scope(Scope newScope) {
+        return new Dependency(
+                newScope,
+                groupId,
+                artifactId,
+                version,
+                versionProperty,
+                requiresLookup,
+                annotationProcessorPriority,
+                order,
+                pom);
+    }
+
     public boolean isAnnotationProcessorPriority() {
         return annotationProcessorPriority;
     }
@@ -166,7 +179,7 @@ public final class Dependency {
             }
         }
 
-        public Builder buildscript() {
+        public Builder buildSrc() {
             return scope(Scope.BUILD);
         }
 
@@ -205,6 +218,10 @@ public final class Dependency {
 
         public Builder profile() {
             return scope(Scope.PROFILE);
+        }
+
+        public Builder classpath() {
+            return scope(Scope.CLASSPATH);
         }
 
         public Builder annotationProcessor(boolean requiresPriority) {

--- a/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Dependency.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Dependency.java
@@ -195,12 +195,12 @@ public final class Dependency {
             return scope(Scope.COMPILE_ONLY);
         }
 
-        public Builder runtime() {
-            return scope(Scope.RUNTIME);
+        public Builder runtimeOnly() {
+            return scope(Scope.RUNTIME_ONLY);
         }
 
-        public Builder test() {
-            return scope(Scope.TEST);
+        public Builder testImplementation() {
+            return scope(Scope.TEST_IMPLEMENTATION);
         }
 
         @SuppressWarnings("unused")
@@ -208,8 +208,8 @@ public final class Dependency {
             return scope(Scope.TEST_COMPILE_ONLY);
         }
 
-        public Builder testRuntime() {
-            return scope(Scope.TEST_RUNTIME);
+        public Builder testRuntimeOnly() {
+            return scope(Scope.TEST_RUNTIME_ONLY);
         }
 
         public Builder annotationProcessor() {

--- a/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Scope.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Scope.java
@@ -30,11 +30,11 @@ public class Scope {
     public static final Scope COMPILE_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.COMPILATION));
     public static final Scope CONSOLE = new Scope(Source.MAIN, Collections.singletonList(Phase.CONSOLE));
     public static final Scope DEVELOPMENT_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.DEVELOPMENT_ONLY));
-    public static final Scope RUNTIME = new Scope(Source.MAIN, Collections.singletonList(Phase.RUNTIME));
-    public static final Scope TEST = new Scope(Source.TEST, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME));
+    public static final Scope RUNTIME_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.RUNTIME));
+    public static final Scope TEST_IMPLEMENTATION = new Scope(Source.TEST, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME));
     public static final Scope TEST_ANNOTATION_PROCESSOR = new Scope(Source.TEST, Collections.singletonList(Phase.ANNOTATION_PROCESSING));
     public static final Scope TEST_COMPILE_ONLY = new Scope(Source.TEST, Collections.singletonList(Phase.COMPILATION));
-    public static final Scope TEST_RUNTIME = new Scope(Source.TEST, Collections.singletonList(Phase.RUNTIME));
+    public static final Scope TEST_RUNTIME_ONLY = new Scope(Source.TEST, Collections.singletonList(Phase.RUNTIME));
     public static final Scope OPENREWRITE = new Scope(Source.MAIN, Collections.singletonList(Phase.OPENREWRITE));
     public static final Scope PROFILE = new Scope(Source.MAIN, Collections.singletonList(Phase.PROFILE));
     public static final Scope CLASSPATH = new Scope(Source.BUILDSCRIPT, Collections.singletonList(Phase.BUILD));

--- a/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Scope.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Scope.java
@@ -37,6 +37,7 @@ public class Scope {
     public static final Scope TEST_RUNTIME = new Scope(Source.TEST, Collections.singletonList(Phase.RUNTIME));
     public static final Scope OPENREWRITE = new Scope(Source.MAIN, Collections.singletonList(Phase.OPENREWRITE));
     public static final Scope PROFILE = new Scope(Source.MAIN, Collections.singletonList(Phase.PROFILE));
+    public static final Scope CLASSPATH = new Scope(Source.BUILDSCRIPT, Collections.singletonList(Phase.BUILD));
 
     @NonNull
     private Source source;

--- a/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Scope.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Scope.java
@@ -26,7 +26,7 @@ public class Scope {
 
     public static final Scope ANNOTATION_PROCESSOR = new Scope(Source.MAIN, Collections.singletonList(Phase.ANNOTATION_PROCESSING));
     public static final Scope BUILD = new Scope(Source.BUILD_SRC, Arrays.asList(Phase.BUILD));
-    public static final Scope COMPILE = new Scope(Source.MAIN, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME));
+    public static final Scope IMPLEMENTATION = new Scope(Source.MAIN, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME));
     public static final Scope COMPILE_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.COMPILATION));
     public static final Scope CONSOLE = new Scope(Source.MAIN, Collections.singletonList(Phase.CONSOLE));
     public static final Scope DEVELOPMENT_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.DEVELOPMENT_ONLY));

--- a/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Source.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/dependencies/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,5 +18,6 @@ package org.grails.forge.build.dependencies;
 public enum Source {
     MAIN,
     TEST,
-    BUILD_SRC
+    BUILD_SRC,
+    BUILDSCRIPT
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleBuild.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleBuild.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,17 @@ public class GradleBuild {
     }
 
     @NonNull
+    public List<GradleDependency> getBuildSrcDependencies() {
+        return buildscriptDependencies.stream().filter(gradleDependency -> !gradleDependency.getConfiguration().equals(GradleConfiguration.CLASSPATH)).collect(Collectors.toList());
+    }
+
+    @NonNull
     public List<GradleDependency> getBuildscriptDependencies() {
+        return buildscriptDependencies.stream().filter(gradleDependency -> gradleDependency.getConfiguration().equals(GradleConfiguration.CLASSPATH)).collect(Collectors.toList());
+    }
+
+    @NonNull
+    public List<GradleDependency> getAllBuildscriptDependencies() {
         return buildscriptDependencies;
     }
 
@@ -82,6 +92,16 @@ public class GradleBuild {
     @NonNull
     public List<GradlePlugin> getPluginsWithVersion() {
         return plugins.stream().filter(plugin -> plugin.getVersion() != null).collect(Collectors.toList());
+    }
+
+    @NonNull
+    public List<GradlePlugin> getPluginsWithoutApply() {
+        return plugins.stream().filter(plugin -> !plugin.useApplyPlugin()).collect(Collectors.toList());
+    }
+
+    @NonNull
+    public List<GradlePlugin> getPluginsWithApply() {
+        return plugins.stream().filter(plugin -> plugin.useApplyPlugin()).collect(Collectors.toList());
     }
 
     @NonNull

--- a/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleConfiguration.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleConfiguration.java
@@ -25,6 +25,7 @@ import org.grails.forge.options.TestFramework;
 import java.util.Optional;
 
 public enum GradleConfiguration implements Ordered {
+    CLASSPATH("classpath", -2),
     PROFILE("profile", -1),
     BUILD("implementation", 0),
     ANNOTATION_PROCESSOR("annotationProcessor", 1),
@@ -72,6 +73,11 @@ public enum GradleConfiguration implements Ordered {
             case BUILD_SRC:
                 if (scope.getPhases().contains(Phase.BUILD)) {
                     return Optional.of(GradleConfiguration.BUILD);
+                }
+                break;
+            case BUILDSCRIPT:
+                if (scope.getPhases().contains(Phase.BUILD)) {
+                    return Optional.of(GradleConfiguration.CLASSPATH);
                 }
                 break;
             case MAIN:

--- a/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleDependency.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,10 +102,10 @@ public class GradleDependency extends DependencyCoordinate {
         String snippet = gradleConfiguration.getConfigurationName();
         if (isPom()) {
             String platformPrefix = " ";
-            snippet += platformPrefix + "platform";
+            snippet += platformPrefix + "platform (";
         }
-        snippet += "(\"" + getGroupId() + ':' + getArtifactId() +
-                (getVersion() != null ? (':' + getVersion()) : "") + "\")";
+        snippet += " \"" + getGroupId() + ':' + getArtifactId() +
+                (getVersion() != null ? (':' + getVersion()) : "") + "\"";
         if (isPom()) {
             snippet += ")";
         }

--- a/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleDependency.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleDependency.java
@@ -99,12 +99,11 @@ public class GradleDependency extends DependencyCoordinate {
 
     @NonNull
     public String toSnippet() {
-        String snippet = gradleConfiguration.getConfigurationName();
+        String snippet = gradleConfiguration.getConfigurationName() + " ";
         if (isPom()) {
-            String platformPrefix = " ";
-            snippet += platformPrefix + "platform (";
+            snippet += "platform(";
         }
-        snippet += " \"" + getGroupId() + ':' + getArtifactId() +
+        snippet += "\"" + getGroupId() + ':' + getArtifactId() +
                 (getVersion() != null ? (':' + getVersion()) : "") + "\"";
         if (isPom()) {
             snippet += ")";

--- a/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradlePlugin.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradlePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ public class GradlePlugin implements BuildPlugin {
     private final boolean requiresLookup;
     private final Set<String> buildImports;
     private final int order;
+    private final boolean useApplyPlugin;
 
     public GradlePlugin(@NonNull String id,
                         @Nullable String version,
@@ -46,6 +47,26 @@ public class GradlePlugin implements BuildPlugin {
                         boolean requiresLookup,
                         int order,
                         Set<String> buildImports) {
+        this(id,
+            version,
+            artifactId,
+            extension,
+            settingsExtension,
+            requiresLookup,
+            order,
+            buildImports,
+            false);
+    }
+
+    public GradlePlugin(@NonNull String id,
+                        @Nullable String version,
+                        @Nullable String artifactId,
+                        @Nullable Writable extension,
+                        @Nullable Writable settingsExtension,
+                        boolean requiresLookup,
+                        int order,
+                        Set<String> buildImports,
+                        boolean useApplyPlugin) {
         this.id = id;
         this.version = version;
         this.artifactId = artifactId;
@@ -54,6 +75,7 @@ public class GradlePlugin implements BuildPlugin {
         this.requiresLookup = requiresLookup;
         this.order = order;
         this.buildImports = buildImports;
+        this.useApplyPlugin = useApplyPlugin;
     }
 
     @Nullable
@@ -98,6 +120,10 @@ public class GradlePlugin implements BuildPlugin {
         return requiresLookup;
     }
 
+    public boolean useApplyPlugin() {
+        return useApplyPlugin;
+    }
+
     @Override
     public BuildPlugin resolved(CoordinateResolver coordinateResolver) {
         Coordinate coordinate = coordinateResolver.resolve(artifactId)
@@ -137,6 +163,7 @@ public class GradlePlugin implements BuildPlugin {
         private boolean requiresLookup;
         private boolean pom = false;
         private int order = 0;
+        private boolean useApplyPlugin = false;
         private boolean template = false;
         private Set<String> buildImports = new HashSet<>();
 
@@ -199,8 +226,13 @@ public class GradlePlugin implements BuildPlugin {
             return this;
         }
 
+        public GradlePlugin.Builder useApplyPlugin(boolean useApplyPlugin) {
+            this.useApplyPlugin = useApplyPlugin;
+            return this;
+        }
+
         public GradlePlugin build() {
-            return new GradlePlugin(id, version, artifactId, extension, settingsExtension, requiresLookup, order, buildImports);
+            return new GradlePlugin(id, version, artifactId, extension, settingsExtension, requiresLookup, order, buildImports, useApplyPlugin);
         }
 
         private GradlePlugin.Builder copy() {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
@@ -70,7 +70,7 @@ public class AssetPipeline implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("com.bertramlabs.plugins")
                 .lookupArtifactId("asset-pipeline-grails")
-                .runtime());
+                .runtimeOnly());
 
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         generatorContext.addTemplate("advancedgrails_svg", new URLTemplate("grails-app/assets/images/advancedgrails.svg", classLoader.getResource("assets/images/advancedgrails.svg")));

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,13 +60,11 @@ public class AssetPipeline implements DefaultFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addBuildscriptDependency(Dependency.builder()
-                .groupId("com.bertramlabs.plugins")
-                .lookupArtifactId("asset-pipeline-gradle")
-                .buildscript());
+
         generatorContext.addBuildPlugin(GradlePlugin.builder()
                 .id("com.bertramlabs.asset-pipeline")
                 .extension(new RockerWritable(assetPipelineExtension.template(generatorContext.getApplicationType())))
+                .lookupArtifactId("asset-pipeline-gradle")
                 .build());
 
         generatorContext.addDependency(Dependency.builder()

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/Gradle.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/Gradle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,7 @@ import org.grails.forge.feature.Feature;
 import org.grails.forge.feature.build.BuildFeature;
 import org.grails.forge.feature.build.gitignore;
 import org.grails.forge.feature.build.gradle.templates.buildGradle;
-import org.grails.forge.feature.build.gradle.templates.buildSrcBuildGradle;
 import org.grails.forge.feature.build.gradle.templates.gradleProperties;
-import org.grails.forge.feature.build.gradle.templates.settingsGradle;
 import org.grails.forge.options.BuildTool;
 import org.grails.forge.options.Options;
 import org.grails.forge.template.BinaryTemplate;
@@ -74,14 +72,6 @@ public class Gradle implements BuildFeature {
         BuildTool buildTool = BuildTool.DEFAULT_OPTION;
         GradleBuild build = dependencyResolver.create(generatorContext);
 
-        generatorContext.addTemplate("buildSrc/build", new RockerTemplate("buildSrc/" + buildTool.getBuildFileName(), buildSrcBuildGradle.template(
-                generatorContext.getApplicationType(),
-                generatorContext.getProject(),
-                generatorContext.getFeatures(),
-                build
-        )));
-
-
         final Function<String, Coordinate> coordinateResolver = (artifactId) -> resolver.resolve(artifactId).orElseThrow(() -> new LookupFailedException(artifactId));
         generatorContext.addTemplate("build", new RockerTemplate(buildTool.getBuildFileName(), buildGradle.template(
                 generatorContext.getApplicationType(),
@@ -94,8 +84,6 @@ public class Gradle implements BuildFeature {
         configureDefaultGradleProps(generatorContext);
         generatorContext.addTemplate("gitignore", new RockerTemplate(".gitignore", gitignore.template()));
         generatorContext.addTemplate("projectProperties", new RockerTemplate("gradle.properties", gradleProperties.template(generatorContext.getBuildProperties().getProperties())));
-        String settingsFile = "settings.gradle";
-        generatorContext.addTemplate("gradleSettings", new RockerTemplate(settingsFile, settingsGradle.template(generatorContext.getProject(), build, coordinateResolver, generatorContext.getFeatures())));
     }
 
     private void configureDefaultGradleProps(GeneratorContext generatorContext) {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/GradleBuildSrc.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/GradleBuildSrc.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.forge.feature.build.gradle;
+
+import jakarta.inject.Singleton;
+import org.grails.forge.application.ApplicationType;
+import org.grails.forge.application.generator.GeneratorContext;
+import org.grails.forge.build.dependencies.CoordinateResolver;
+import org.grails.forge.build.gradle.GradleBuild;
+import org.grails.forge.build.gradle.GradleBuildCreator;
+import org.grails.forge.feature.build.gradle.templates.buildSrcBuildGradle;
+import org.grails.forge.options.BuildTool;
+import org.grails.forge.template.RockerTemplate;
+
+@Singleton
+public class GradleBuildSrc implements GradleBuildSrcFeature {
+
+    private final GradleBuildCreator dependencyResolver;
+    private final CoordinateResolver resolver;
+
+    public GradleBuildSrc(GradleBuildCreator dependencyResolver, CoordinateResolver resolver) {
+        this.dependencyResolver = dependencyResolver;
+        this.resolver = resolver;
+    }
+
+    @Override
+    public String getName() {
+        return "gradle-build-src";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Gradle buildSrc";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Use Gradle buildSrc/build.gradle instead of buildscript{} in main build.gradle";
+    }
+
+    @Override
+    public boolean isVisible() {
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        BuildTool buildTool = BuildTool.DEFAULT_OPTION;
+        GradleBuild build = dependencyResolver.create(generatorContext);
+
+        generatorContext.addTemplate("buildSrc/build", new RockerTemplate("buildSrc/" + buildTool.getBuildFileName(), buildSrcBuildGradle.template(
+                generatorContext.getApplicationType(),
+                generatorContext.getProject(),
+                generatorContext.getFeatures(),
+                build
+        )));
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+}

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/GradleBuildSrcFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/GradleBuildSrcFeature.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.forge.feature.build.gradle;
+
+import org.grails.forge.application.ApplicationType;
+import org.grails.forge.feature.Category;
+import org.grails.forge.feature.OneOfFeature;
+
+public interface GradleBuildSrcFeature extends OneOfFeature {
+
+    @Override
+    default Class<?> getFeatureClass() {
+        return GradleBuildSrcFeature.class;
+    }
+
+    @Override
+    default boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    default String getCategory() {
+        return Category.CONFIGURATION;
+    }
+}

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/GradleSettingsFile.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/GradleSettingsFile.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.forge.feature.build.gradle;
+
+import jakarta.inject.Singleton;
+import org.grails.forge.application.ApplicationType;
+import org.grails.forge.application.generator.GeneratorContext;
+import org.grails.forge.build.dependencies.Coordinate;
+import org.grails.forge.build.dependencies.CoordinateResolver;
+import org.grails.forge.build.dependencies.LookupFailedException;
+import org.grails.forge.build.gradle.GradleBuild;
+import org.grails.forge.build.gradle.GradleBuildCreator;
+import org.grails.forge.feature.build.gradle.templates.settingsGradle;
+import org.grails.forge.options.BuildTool;
+import org.grails.forge.template.RockerTemplate;
+
+import java.util.function.Function;
+
+@Singleton
+public class GradleSettingsFile implements GradleSettingsFileFeature {
+
+    private final GradleBuildCreator dependencyResolver;
+    private final CoordinateResolver resolver;
+
+    public GradleSettingsFile(GradleBuildCreator dependencyResolver, CoordinateResolver resolver) {
+        this.dependencyResolver = dependencyResolver;
+        this.resolver = resolver;
+    }
+
+    @Override
+    public String getName() {
+        return "gradle-settings-file";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Gradle Settings File";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Generate Gradle Settings File for use in multi-project builds and with Gradle Settings Plugins";
+    }
+
+    @Override
+    public boolean isVisible() {
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        BuildTool buildTool = BuildTool.DEFAULT_OPTION;
+        GradleBuild build = dependencyResolver.create(generatorContext);
+
+        String settingsFile = "settings.gradle";
+        final Function<String, Coordinate> coordinateResolver = (artifactId) -> resolver.resolve(artifactId).orElseThrow(() -> new LookupFailedException(artifactId));
+        generatorContext.addTemplate("gradleSettings", new RockerTemplate(settingsFile, settingsGradle.template(generatorContext.getProject(), build, coordinateResolver, generatorContext.getFeatures())));
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+}

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/GradleSettingsFileFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/GradleSettingsFileFeature.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.forge.feature.build.gradle;
+
+import org.grails.forge.application.ApplicationType;
+import org.grails.forge.feature.Category;
+import org.grails.forge.feature.OneOfFeature;
+
+public interface GradleSettingsFileFeature extends OneOfFeature {
+
+    @Override
+    default Class<?> getFeatureClass() {
+        return GradleSettingsFileFeature.class;
+    }
+
+    @Override
+    default boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    default String getCategory() {
+        return Category.CONFIGURATION;
+    }
+}

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -85,7 +85,7 @@ configurations {
 
 @if (features.mainClass().isPresent()) {
 application {
-    mainClass.set("@features.mainClass().get()")
+    mainClass = "@features.mainClass().get()"
 }
 
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -9,6 +9,7 @@
 @import org.grails.forge.feature.Features
 @import org.grails.forge.options.TestFramework
 @import org.grails.forge.util.VersionInfo
+@import org.grails.forge.build.gradle.GradleDependency
 
 @args (
 ApplicationType applicationType,
@@ -18,16 +19,44 @@ Features features,
 GradleBuild gradleBuild
 )
 
-@seleniumVersion => { @coordinateResolver.apply("selenium-api").getVersion() }
+@seleniumVersion => {@coordinateResolver.apply("selenium-api").getVersion()}
+
+
+@if (!features.contains("gradle-build-src") && !gradleBuild.getBuildscriptDependencies().isEmpty()) {
+buildscript {
+    repositories {
+        maven { url "https://repo.grails.org/grails/core" }
+        mavenCentral()
+    }
+    dependencies { // Not Published to Gradle Plugin Portal
+    @for (GradleDependency dependency : gradleBuild.getBuildscriptDependencies()) {
+        @dependency.toSnippet()
+    }
+    }
+}
+
+}
 
 @for (String importLine : gradleBuild.getPluginsImports()) {
 @(importLine)
 }
 plugins {
-@for (GradlePlugin gradlePlugin : gradleBuild.getPlugins()) {
+@for (GradlePlugin gradlePlugin : gradleBuild.getPluginsWithoutApply()) {
+    @if(gradlePlugin.getVersion() != null) {
+    id "@gradlePlugin.getId()" version "@gradlePlugin.getVersion()"
+    } else {
     id "@gradlePlugin.getId()"
+    }
 }
 }
+
+@if(!gradleBuild.getPluginsWithApply().isEmpty()) {
+// Not Published to Gradle Plugin Portal
+@for (GradlePlugin gradlePlugin : gradleBuild.getPluginsWithApply()) {
+apply plugin: "@gradlePlugin.getId()"
+}
+}
+
 
 group = "@project.getPackageName()"
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -11,13 +11,13 @@ Features features,
 GradleBuild gradleBuild
 )
 
-@if(!gradleBuild.getBuildscriptDependencies().isEmpty()) {
+@if(!gradleBuild.getBuildSrcDependencies().isEmpty()) {
 repositories {
-    mavenCentral()
     maven { url "https://repo.grails.org/grails/core/" }
+    mavenCentral()
 }
 dependencies {
-@for (GradleDependency dependency : gradleBuild.getBuildscriptDependencies()) {
+@for (GradleDependency dependency : gradleBuild.getBuildSrcDependencies()) {
     @dependency.toSnippet()
 }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -3,6 +3,7 @@
 @import org.grails.forge.feature.Features
 @import org.grails.forge.build.gradle.GradleBuild
 @import org.grails.forge.build.gradle.GradleDependency
+@import org.grails.forge.util.VersionInfo
 
 @args (
 ApplicationType applicationType,
@@ -17,6 +18,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
+    implementation platform("org.grails:grails-bom:@VersionInfo.getGrailsVersion()")
 @for (GradleDependency dependency : gradleBuild.getBuildSrcDependencies()) {
     @dependency.toSnippet()
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/dependencies.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/dependencies.rocker.raw
@@ -2,7 +2,6 @@
 @import org.grails.forge.application.Project
 @import org.grails.forge.build.gradle.GradleBuild
 @import org.grails.forge.build.gradle.GradleDependency
-@import org.grails.forge.feature.build.gradle.templates.dependency
 @import org.grails.forge.feature.Features
 
 @args (
@@ -15,16 +14,5 @@ GradleBuild gradleBuild
 dependencies {
 @for (GradleDependency dependency : gradleBuild.getDependencies()) {
     @dependency.toSnippet()
-}
-
-@if (features.contains("hamcrest")) {
-    @dependency.template("org.hamcrest","hamcrest", "testImplementation", null, false)
-}
-
-@if (!features.contains("micronaut-http-client")) {
-    @dependency.template("io.micronaut", "micronaut-http-client", "testImplementation", null, false)
-}
-@if (features.contains("neo4j-bolt")) {
-    @dependency.template("org.neo4j.test", "neo4j-harness", "testRuntimeOnly", null, false)
 }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/dependency.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/dependency.rocker.raw
@@ -1,3 +1,3 @@
 @args(String groupId, String artifactId, String scope, String version, boolean pom)
 
-@(pom ? scope + " platform" : scope)("@groupId:@artifactId@(version != null ? ":" + version : "")")
+@(pom ? scope + " platform" : scope) "@groupId:@artifactId@(version != null ? ":" + version : "")"

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/dependency.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/dependency.rocker.raw
@@ -1,3 +1,0 @@
-@args(String groupId, String artifactId, String scope, String version, boolean pom)
-
-@(pom ? scope + " platform" : scope) "@groupId:@artifactId@(version != null ? ":" + version : "")"

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/settingsGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/settingsGradle.rocker.raw
@@ -12,39 +12,5 @@ GradleBuild gradleBuild,
 Function<String, Coordinate> coordinateResolver,
 Features features)
 
-@grailsGradlePluginVersion => { @coordinateResolver.apply("grails-gradle-plugin").getVersion() }
-@viewsGradlePluginVersion => { @coordinateResolver.apply("views-gradle").getVersion() }
-@assetPipelineVersion => { @coordinateResolver.apply("asset-pipeline-grails").getVersion() }
-
 @gradleBuild.renderSettingsExtensions()
-
-pluginManagement {
-    repositories {
-        mavenLocal()
-        maven { url "https://repo.grails.org/grails/core/" }
-        gradlePluginPortal()
-    }
-    plugins {
-        @if(features.contains("grails-web")) {
-        id "org.grails.grails-web" version "@grailsGradlePluginVersion"
-        }
-        @if(features.contains("grails-gsp")) {
-        id "org.grails.grails-gsp" version "@grailsGradlePluginVersion"
-        }
-        @if(features.contains("views-json")) {
-        id "org.grails.plugins.views-json" version "@viewsGradlePluginVersion"
-        }
-        @if(features.contains("views-markup"))  {
-        id "org.grails.plugins.views-markup" version "@viewsGradlePluginVersion"
-        }
-        @if(features.contains("asset-pipeline-grails")) {
-        id "com.bertramlabs.asset-pipeline" version "@assetPipelineVersion"
-        }
-
-    @for (GradlePlugin gradlePlugin : gradleBuild.getPluginsWithVersion()) {
-        id "@gradlePlugin.getId()" version "@gradlePlugin.getVersion()"
-    }
-    }
-}
-
 rootProject.name="@project.getName()"

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/cache/EHCache.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/cache/EHCache.java
@@ -47,7 +47,7 @@ public class EHCache implements CacheFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .lookupArtifactId("cache-ehcache")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/cache/GrailsCache.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/cache/GrailsCache.java
@@ -51,7 +51,7 @@ public class GrailsCache implements Feature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .lookupArtifactId("cache")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/EmbeddedMongo.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/EmbeddedMongo.java
@@ -83,6 +83,6 @@ public class EmbeddedMongo implements Feature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .lookupArtifactId("embedded-mongodb")
-                .scope(Scope.TEST_RUNTIME));
+                .scope(Scope.TEST_RUNTIME_ONLY));
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/H2.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/H2.java
@@ -84,6 +84,6 @@ public class H2 extends DatabaseDriverFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("com.h2database")
                 .artifactId("h2")
-                .runtime());
+                .runtimeOnly());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -86,7 +86,7 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .artifactId("hibernate5")
-                .compile());
+                .implementation());
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.apache.tomcat")
                 .artifactId("tomcat-jdbc")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -82,7 +82,7 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .lookupArtifactId("hibernate5")
-                .buildscript());
+                .buildSrc());
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .artifactId("hibernate5")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -90,7 +90,7 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.apache.tomcat")
                 .artifactId("tomcat-jdbc")
-                .runtime());
+                .runtimeOnly());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/MongoGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/MongoGorm.java
@@ -68,7 +68,7 @@ public class MongoGorm extends GormOneOfFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .artifactId("mongodb")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/MongoSync.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/MongoSync.java
@@ -52,7 +52,7 @@ public class MongoSync extends MongoFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.mongodb")
                 .lookupArtifactId("mongodb-driver-sync")
-                .compile()
+                .implementation()
         );
     }
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/MySQL.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/MySQL.java
@@ -88,6 +88,6 @@ public class MySQL extends DatabaseDriverFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("mysql")
                 .artifactId("mysql-connector-java")
-                .runtime());
+                .runtimeOnly());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/Neo4jGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/Neo4jGorm.java
@@ -53,7 +53,7 @@ public class Neo4jGorm extends GormOneOfFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .artifactId("neo4j")
-                .compile());
+                .implementation());
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.neo4j.test")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/Neo4jGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/Neo4jGorm.java
@@ -54,6 +54,11 @@ public class Neo4jGorm extends GormOneOfFeature {
                 .groupId("org.grails.plugins")
                 .artifactId("neo4j")
                 .compile());
+
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("org.neo4j.test")
+                .artifactId("neo4j-harness")
+                .testRuntimeOnly());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/PostgreSQL.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/PostgreSQL.java
@@ -89,6 +89,6 @@ public class PostgreSQL extends DatabaseDriverFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.postgresql")
                 .artifactId("postgresql")
-                .runtime());
+                .runtimeOnly());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/SQLServer.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/SQLServer.java
@@ -88,6 +88,6 @@ public class SQLServer extends DatabaseDriverFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("com.microsoft.sqlserver")
                 .artifactId("mssql-jdbc")
-                .runtime());
+                .runtimeOnly());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/TestContainers.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/TestContainers.java
@@ -83,7 +83,7 @@ public class TestContainers implements Feature {
         return Dependency.builder()
                 .groupId(TESTCONTAINERS_GROUP_ID)
                 .artifactId(artifactId)
-                .test();
+                .testImplementation();
     }
 
     @NonNull

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsBase.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsBase.java
@@ -54,15 +54,15 @@ public class GrailsBase implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("grails-core")
-                .compile());
+                .implementation());
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("grails-web-boot")
-                .compile());
+                .implementation());
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("grails-logging")
-                .compile());
+                .implementation());
 
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         generatorContext.addTemplate("src/main/groovy", new URLTemplate("src/main/groovy/.gitkeep", classLoader.getResource(".gitkeep")));

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsDefaultPlugins.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsDefaultPlugins.java
@@ -57,7 +57,7 @@ public class GrailsDefaultPlugins implements DefaultFeature {
                     generatorContext.addDependency(Dependency.builder()
                             .groupId("org.grails")
                             .artifactId("grails-plugin-" + artifact)
-                            .compile());
+                            .implementation());
                 });
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         generatorContext.addTemplate("messages_properties", new URLTemplate("grails-app/i18n/messages.properties", classLoader.getResource("i18n/messages.properties"), false));

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsGradlePlugin.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsGradlePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,15 +68,15 @@ class GrailsGradlePlugin implements DefaultFeature {
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.grails")
                 .lookupArtifactId("grails-gradle-plugin")
-                .buildscript());
+                .buildSrc());
         if (applicationType == ApplicationType.PLUGIN || applicationType == ApplicationType.WEB_PLUGIN) {
-            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-plugin").build());
+            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-plugin").version(grailsGradlePluginCoordinate.getVersion()).useApplyPlugin(true).build());
         }
         if (generatorContext.getFeature(GrailsWeb.class).isPresent()) {
-            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-web").build());
+            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-web").version(grailsGradlePluginCoordinate.getVersion()).useApplyPlugin(true).build());
         }
         if (generatorContext.getFeature(GrailsGsp.class).isPresent()) {
-            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-gsp").build());
+            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-gsp").version(grailsGradlePluginCoordinate.getVersion()).useApplyPlugin(true).build());
         }
         generatorContext.getBuildProperties().put("grailsGradlePluginVersion", grailsGradlePluginCoordinate.getVersion());
     }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsWebConsole.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsWebConsole.java
@@ -52,7 +52,7 @@ public class GrailsWebConsole implements Feature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .lookupArtifactId("grails-console")
-                .runtime());
+                .runtimeOnly());
 
         final Map<String, Object> config = generatorContext.getConfiguration();
         config.put("environments.production.grails.plugin.console.enabled", false);

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/logging/Logback.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/logging/Logback.java
@@ -67,7 +67,7 @@ public class Logback implements LoggingFeature, DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("grails-logging")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/logging/LogbackGroovy.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/logging/LogbackGroovy.java
@@ -64,13 +64,13 @@ public class LogbackGroovy implements LoggingFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("grails-logging")
-                .compile());
+                .implementation());
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("io.github.virtualdogbert")
                 .artifactId("logback-groovy-config")
                 .version("1.12.4")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/micronaut/MicronautInjectGroovy.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/micronaut/MicronautInjectGroovy.java
@@ -51,6 +51,6 @@ public class MicronautInjectGroovy implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("io.micronaut")
                 .artifactId("micronaut-inject-groovy")
-                .test());
+                .testImplementation());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
@@ -59,7 +59,7 @@ public class DatabaseMigrationPlugin implements MigrationFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .lookupArtifactId("database-migration")
-                .compile());
+                .implementation());
     }
 
     private String getSrcDirPath() {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class DatabaseMigrationPlugin implements MigrationFeature {
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .lookupArtifactId("database-migration")
-                .buildscript()
+                .buildSrc()
                 .extension(new RockerWritable(dbMigrationGradle.template(srcDirPath))));
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/other/GrailsQuartz.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/other/GrailsQuartz.java
@@ -48,7 +48,7 @@ public class GrailsQuartz implements Feature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .lookupArtifactId("quartz")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/other/HibernateValidator.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/other/HibernateValidator.java
@@ -50,7 +50,7 @@ public class HibernateValidator implements Feature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.hibernate")
                 .lookupArtifactId("hibernate-validator")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/other/MicronautHttpClient.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/other/MicronautHttpClient.java
@@ -63,5 +63,10 @@ public class MicronautHttpClient implements Feature {
                 .groupId("io.micronaut")
                 .artifactId("micronaut-http-client")
                 .compile());
+
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("io.micronaut")
+                .artifactId("micronaut-http-client")
+                .testImplementation());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/other/MicronautHttpClient.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/other/MicronautHttpClient.java
@@ -62,7 +62,7 @@ public class MicronautHttpClient implements Feature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("io.micronaut")
                 .artifactId("micronaut-http-client")
-                .compile());
+                .implementation());
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("io.micronaut")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootAutoconfigure.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootAutoconfigure.java
@@ -53,7 +53,7 @@ public class SpringBootAutoconfigure implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.springframework.boot")
                 .artifactId("spring-boot-autoconfigure")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootJettyFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootJettyFeature.java
@@ -50,7 +50,7 @@ public class SpringBootJettyFeature extends SpringBootEmbeddedServlet {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.springframework.boot")
                 .artifactId("spring-boot-starter-jetty")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootStarterFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootStarterFeature.java
@@ -55,19 +55,19 @@ public class SpringBootStarterFeature implements DefaultFeature {
             generatorContext.addDependency(Dependency.builder()
                     .groupId("org.springframework.boot")
                     .artifactId("spring-boot-starter")
-                    .compile());
+                    .implementation());
             generatorContext.addDependency(Dependency.builder()
                     .groupId("org.springframework.boot")
                     .artifactId("spring-boot-starter-actuator")
-                    .compile());
+                    .implementation());
         }
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.springframework.boot")
                 .artifactId("spring-boot-starter-validation")
-                .compile());
+                .implementation());
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.springframework.boot")
                 .artifactId("spring-boot-starter-logging")
-                .compile());
+                .implementation());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootTomcatFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootTomcatFeature.java
@@ -52,7 +52,7 @@ public class SpringBootTomcatFeature extends SpringBootEmbeddedServlet {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.springframework.boot")
                 .artifactId("spring-boot-starter-tomcat")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootUndertowFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootUndertowFeature.java
@@ -50,7 +50,7 @@ public class SpringBootUndertowFeature extends SpringBootEmbeddedServlet {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.springframework.boot")
                 .artifactId("spring-boot-starter-undertow")
-                .compile());
+                .implementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/AssertJ.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/AssertJ.java
@@ -50,7 +50,7 @@ public class AssertJ implements Feature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.assertj")
                 .artifactId("assertj-core")
-                .test());
+                .testImplementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/Geb.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/Geb.java
@@ -103,27 +103,27 @@ public class Geb implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .artifactId("geb")
-                .test());
+                .testImplementation());
 
         Stream.of("api", "support", "remote-driver")
                 .map(name -> "selenium-" + name)
                 .forEach(name -> generatorContext.addDependency(Dependency.builder()
                         .groupId("org.seleniumhq.selenium")
                         .lookupArtifactId(name)
-                        .test()));
+                        .testImplementation()));
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.seleniumhq.selenium")
                 .lookupArtifactId("selenium-chrome-driver")
-                .testRuntime());
+                .testRuntimeOnly());
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.seleniumhq.selenium")
                 .lookupArtifactId("selenium-firefox-driver")
-                .testRuntime());
+                .testRuntimeOnly());
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.seleniumhq.selenium")
                 .lookupArtifactId("selenium-safari-driver")
-                .testRuntime());
+                .testRuntimeOnly());
 
         TestFramework testFramework = generatorContext.getTestFramework();
         String integrationTestSourcePath = generatorContext.getIntegrationTestSourcePath("/{packagePath}/{className}");

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/GormTestingSupport.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/GormTestingSupport.java
@@ -52,6 +52,6 @@ public class GormTestingSupport implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("grails-gorm-testing-support")
-                .test());
+                .testImplementation());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/GrailsWebTestingSupport.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/GrailsWebTestingSupport.java
@@ -52,6 +52,6 @@ public class GrailsWebTestingSupport implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("grails-web-testing-support")
-                .test());
+                .testImplementation());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/Hamcrest.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/Hamcrest.java
@@ -17,6 +17,8 @@ package org.grails.forge.feature.test;
 
 import jakarta.inject.Singleton;
 import org.grails.forge.application.ApplicationType;
+import org.grails.forge.application.generator.GeneratorContext;
+import org.grails.forge.build.dependencies.Dependency;
 import org.grails.forge.feature.Category;
 import org.grails.forge.feature.Feature;
 
@@ -51,5 +53,13 @@ public class Hamcrest  implements Feature {
     @Override
     public String getThirdPartyDocumentation() {
         return "https://hamcrest.org/JavaHamcrest/";
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("org.hamcrest")
+                .artifactId("hamcrest")
+                .testImplementation());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/Junit.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/Junit.java
@@ -52,7 +52,7 @@ public class Junit implements TestFeature, DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.junit.jupiter")
                 .lookupArtifactId("junit-jupiter")
-                .test());
+                .testImplementation());
     }
 
     @Override

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/Mockito.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/Mockito.java
@@ -69,6 +69,6 @@ public class Mockito implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                         .groupId("org.mockito")
                         .artifactId("mockito-core")
-                .test());
+                .testImplementation());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/Spock.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/Spock.java
@@ -39,7 +39,7 @@ public class Spock implements TestFeature, DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                         .groupId("org.spockframework")
                         .artifactId("spock-core")
-                        .test()
+                        .testImplementation()
                 .build());
     }
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/ViewsJsonTestingSupport.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/ViewsJsonTestingSupport.java
@@ -52,6 +52,6 @@ public class ViewsJsonTestingSupport implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("views-json-testing-support")
-                .test());
+                .testImplementation());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
@@ -99,7 +99,7 @@ public class GrailsGsp implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .artifactId("gsp")
-                .compile());
+                .implementation());
 
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         generatorContext.addTemplate("mainLayout", new URLTemplate(getViewFolderPath() + "layouts/main.gsp", classLoader.getResource("gsp/main.gsp")));

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import jakarta.inject.Singleton;
 import org.grails.forge.application.ApplicationType;
 import org.grails.forge.application.generator.GeneratorContext;
 import org.grails.forge.build.dependencies.Dependency;
-import org.grails.forge.build.gradle.GradlePlugin;
 import org.grails.forge.feature.Category;
 import org.grails.forge.feature.DefaultFeature;
 import org.grails.forge.feature.Feature;
@@ -101,7 +100,6 @@ public class GrailsGsp implements DefaultFeature {
                 .groupId("org.grails.plugins")
                 .artifactId("gsp")
                 .compile());
-        generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-gsp").build());
 
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         generatorContext.addTemplate("mainLayout", new URLTemplate(getViewFolderPath() + "layouts/main.gsp", classLoader.getResource("gsp/main.gsp")));

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/Scaffolding.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/Scaffolding.java
@@ -87,6 +87,6 @@ public class Scaffolding implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .artifactId("scaffolding")
-                .compile());
+                .implementation());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/Scaffolding.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/Scaffolding.java
@@ -82,7 +82,7 @@ public class Scaffolding implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.fusesource.jansi")
                 .lookupArtifactId("jansi")
-                .runtime());
+                .runtimeOnly());
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/ViewJson.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/ViewJson.java
@@ -94,7 +94,7 @@ public class ViewJson extends GrailsViews implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("views-json-testing-support")
-                .test());
+                .testImplementation());
 
         generatorContext.addTemplate("application_index_gson", new RockerTemplate(getViewFolderPath() + "application/index.gson", index.template()));
         generatorContext.addTemplate("_errors_gson", new RockerTemplate(getViewFolderPath() + "errors/_errors.gson", _errors.template()));

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/ViewJson.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/ViewJson.java
@@ -85,11 +85,11 @@ public class ViewJson extends GrailsViews implements DefaultFeature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .artifactId("views-json")
-                .compile());
+                .implementation());
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .artifactId("views-json-templates")
-                .compile());
+                .implementation());
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/ViewJson.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/ViewJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,9 +75,12 @@ public class ViewJson extends GrailsViews implements DefaultFeature {
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .lookupArtifactId("views-gradle")
-                .buildscript());
+                .buildSrc());
 
-        generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.plugins.views-json").build());
+        generatorContext.addBuildPlugin(GradlePlugin.builder()
+                .id("org.grails.plugins.views-json")
+                .lookupArtifactId("views-gradle")
+                .build());
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/markup/ViewMarkup.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/markup/ViewMarkup.java
@@ -81,7 +81,7 @@ public class ViewMarkup extends GrailsViews implements Feature {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .artifactId("views-markup")
-                .compile());
+                .implementation());
 
         generatorContext.addTemplate("application_index_gml", new RockerTemplate(getViewFolderPath() + "application/index.gml", index.template()));
         generatorContext.addTemplate("_errors_gml", new RockerTemplate(getViewFolderPath() + "errors/_errors.gml", _errors.template()));

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/markup/ViewMarkup.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/markup/ViewMarkup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,9 +71,12 @@ public class ViewMarkup extends GrailsViews implements Feature {
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
                 .lookupArtifactId("views-gradle")
-                .buildscript());
+                .buildSrc());
 
-        generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.plugins.views-markup").build());
+        generatorContext.addBuildPlugin(GradlePlugin.builder()
+                .id("org.grails.plugins.views-markup")
+                .lookupArtifactId("views-gradle")
+                .build());
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/web/GrailsWeb.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/web/GrailsWeb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.grails.forge.feature.web;
 import jakarta.inject.Singleton;
 import org.grails.forge.application.ApplicationType;
 import org.grails.forge.application.generator.GeneratorContext;
-import org.grails.forge.build.gradle.GradlePlugin;
 import org.grails.forge.feature.DefaultFeature;
 import org.grails.forge.feature.Feature;
 import org.grails.forge.options.Options;
@@ -53,6 +52,5 @@ public class GrailsWeb implements DefaultFeature {
     public void apply(GeneratorContext generatorContext) {
         final Map<String, Object> config = generatorContext.getConfiguration();
         config.put("grails.views.default.codec", "html");
-        generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-web").build());
     }
 }

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -125,12 +125,12 @@
         <dependency>
             <groupId>com.bertramlabs.plugins</groupId>
             <artifactId>asset-pipeline-grails</artifactId>
-            <version>4.3.0</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.bertramlabs.plugins</groupId>
             <artifactId>asset-pipeline-gradle</artifactId>
-            <version>4.3.0</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -125,12 +125,12 @@
         <dependency>
             <groupId>com.bertramlabs.plugins</groupId>
             <artifactId>asset-pipeline-grails</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.bertramlabs.plugins</groupId>
             <artifactId>asset-pipeline-gradle</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -125,12 +125,12 @@
         <dependency>
             <groupId>com.bertramlabs.plugins</groupId>
             <artifactId>asset-pipeline-grails</artifactId>
-            <version>4.5.1</version>
+            <version>4.5.2</version>
         </dependency>
         <dependency>
             <groupId>com.bertramlabs.plugins</groupId>
             <artifactId>asset-pipeline-gradle</artifactId>
-            <version>4.5.1</version>
+            <version>4.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/grails-forge-core/src/test/groovy/org/grails/forge/ApplicationContextSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/ApplicationContextSpec.groovy
@@ -34,7 +34,7 @@ abstract class ApplicationContextSpec extends Specification implements ProjectFi
         for (String line : lines) {
             if (line.contains(groupArtifactId)) {
                 String str = line.substring(line.indexOf(groupArtifactId) + groupArtifactId.length() + ":".length())
-                String version = str.substring(0, str.indexOf("\")"))
+                String version = str.substring(0, str.indexOf("\""))
                 return Optional.of(new SemanticVersion(version))
             }
         }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/BuildBuilder.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/BuildBuilder.groovy
@@ -101,6 +101,7 @@ class BuildBuilder implements ProjectFixture, ContextFixture {
 
     String renderBuildSrc() {
         List<String> featureNames = this.features ?: []
+        featureNames.add("gradle-build-src")
         TestFramework testFramework = this.testFramework ?: TestFramework.SPOCK
         ApplicationType type = this.applicationType ?: ApplicationType.WEB
         Project project = this.project ?: buildProject()

--- a/grails-forge-core/src/test/groovy/org/grails/forge/build/dependencies/GradleDependencyComparatorSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/build/dependencies/GradleDependencyComparatorSpec.groovy
@@ -32,23 +32,23 @@ class GradleDependencyComparatorSpec extends Specification {
         dependencies.sort(GradleDependency.COMPARATOR)
 
         then:
-        "${str(dependencies[0])}" == 'implementation("io.micronaut:micronaut-http-client")'
-        "${str(dependencies[1])}" == 'implementation("io.micronaut:micronaut-runtime")'
-        "${str(dependencies[2])}" == 'implementation("io.micronaut:micronaut-validation")'
-        "${str(dependencies[3])}" == 'implementation("io.micronaut.sql:micronaut-jdbc-hikari")'
-        "${str(dependencies[4])}" == 'implementation("io.swagger.core.v3:swagger-annotations")'
-        "${str(dependencies[5])}" == 'implementation("jakarta.annotation:jakarta.annotation-api")'
-        "${str(dependencies[6])}" == 'compileOnly("io.micronaut.openapi:micronaut-openapi")'
-        "${str(dependencies[7])}" == 'console("org.grails:grails-console")'
-        "${str(dependencies[8])}" == 'runtimeOnly("ch.qos.logback:logback-classic")'
-        "${str(dependencies[9])}" == 'runtimeOnly("mysql:mysql-connector-java")'
-        "${str(dependencies[10])}" == 'testImplementation("org.testcontainers:junit-jupiter")'
-        "${str(dependencies[11])}" == 'testImplementation("org.testcontainers:mysql")'
-        "${str(dependencies[12])}" == 'testImplementation("org.testcontainers:testcontainers")'
+        "${str(dependencies[0])}" == 'implementation "io.micronaut:micronaut-http-client"'
+        "${str(dependencies[1])}" == 'implementation "io.micronaut:micronaut-runtime"'
+        "${str(dependencies[2])}" == 'implementation "io.micronaut:micronaut-validation"'
+        "${str(dependencies[3])}" == 'implementation "io.micronaut.sql:micronaut-jdbc-hikari"'
+        "${str(dependencies[4])}" == 'implementation "io.swagger.core.v3:swagger-annotations"'
+        "${str(dependencies[5])}" == 'implementation "jakarta.annotation:jakarta.annotation-api"'
+        "${str(dependencies[6])}" == 'compileOnly "io.micronaut.openapi:micronaut-openapi"'
+        "${str(dependencies[7])}" == 'console "org.grails:grails-console"'
+        "${str(dependencies[8])}" == 'runtimeOnly "ch.qos.logback:logback-classic"'
+        "${str(dependencies[9])}" == 'runtimeOnly "mysql:mysql-connector-java"'
+        "${str(dependencies[10])}" == 'testImplementation "org.testcontainers:junit-jupiter"'
+        "${str(dependencies[11])}" == 'testImplementation "org.testcontainers:mysql"'
+        "${str(dependencies[12])}" == 'testImplementation "org.testcontainers:testcontainers"'
     }
 
     private static String str(GradleDependency dependency) {
-        "${dependency.getConfiguration().toString()}(\"${dependency.groupId}:${dependency.artifactId}\")"
+        "${dependency.getConfiguration().toString()} \"${dependency.groupId}:${dependency.artifactId}\""
     }
 
     private static GradleDependency dep(Dependency.Builder dependency, GeneratorContext ctx) {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/build/dependencies/GradleDependencyComparatorSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/build/dependencies/GradleDependencyComparatorSpec.groovy
@@ -13,13 +13,13 @@ class GradleDependencyComparatorSpec extends Specification {
             getTestFramework() >> TestFramework.JUNIT
         }
         List<GradleDependency> dependencies =
-                [dep(Dependency.builder().groupId("io.micronaut").artifactId("micronaut-validation").compile(), ctx),
-                 dep(Dependency.builder().groupId("io.swagger.core.v3").artifactId("swagger-annotations").compile(), ctx),
-                 dep(Dependency.builder().groupId("io.micronaut").artifactId("micronaut-runtime").compile(), ctx),
-                 dep(Dependency.builder().groupId("jakarta.annotation").artifactId("jakarta.annotation-api").compile(), ctx),
-                 dep(Dependency.builder().groupId("io.micronaut").artifactId("micronaut-http-client").compile(), ctx),
+                [dep(Dependency.builder().groupId("io.micronaut").artifactId("micronaut-validation").implementation(), ctx),
+                 dep(Dependency.builder().groupId("io.swagger.core.v3").artifactId("swagger-annotations").implementation(), ctx),
+                 dep(Dependency.builder().groupId("io.micronaut").artifactId("micronaut-runtime").implementation(), ctx),
+                 dep(Dependency.builder().groupId("jakarta.annotation").artifactId("jakarta.annotation-api").implementation(), ctx),
+                 dep(Dependency.builder().groupId("io.micronaut").artifactId("micronaut-http-client").implementation(), ctx),
                  dep(Dependency.builder().groupId("io.micronaut.openapi").artifactId("micronaut-openapi").annotationProcessor(), ctx),
-                 dep(Dependency.builder().groupId("io.micronaut.sql").artifactId("micronaut-jdbc-hikari").compile(), ctx),
+                 dep(Dependency.builder().groupId("io.micronaut.sql").artifactId("micronaut-jdbc-hikari").implementation(), ctx),
                  dep(Dependency.builder().groupId("org.grails").artifactId("grails-console").console(), ctx),
                  dep(Dependency.builder().groupId("org.testcontainers").artifactId("testcontainers").testImplementation(), ctx),
                  dep(Dependency.builder().groupId("mysql").artifactId("mysql-connector-java").runtimeOnly(), ctx),

--- a/grails-forge-core/src/test/groovy/org/grails/forge/build/dependencies/GradleDependencyComparatorSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/build/dependencies/GradleDependencyComparatorSpec.groovy
@@ -2,7 +2,6 @@ package org.grails.forge.build.dependencies
 
 import org.grails.forge.application.generator.GeneratorContext
 import org.grails.forge.build.gradle.GradleDependency
-import org.grails.forge.options.Language
 import org.grails.forge.options.TestFramework
 import spock.lang.Specification
 
@@ -22,11 +21,11 @@ class GradleDependencyComparatorSpec extends Specification {
                  dep(Dependency.builder().groupId("io.micronaut.openapi").artifactId("micronaut-openapi").annotationProcessor(), ctx),
                  dep(Dependency.builder().groupId("io.micronaut.sql").artifactId("micronaut-jdbc-hikari").compile(), ctx),
                  dep(Dependency.builder().groupId("org.grails").artifactId("grails-console").console(), ctx),
-                 dep(Dependency.builder().groupId("org.testcontainers").artifactId("testcontainers").test(), ctx),
-                 dep(Dependency.builder().groupId("mysql").artifactId("mysql-connector-java").runtime(), ctx),
-                 dep(Dependency.builder().groupId("org.testcontainers").artifactId("junit-jupiter").test(), ctx),
-                 dep(Dependency.builder().groupId("org.testcontainers").artifactId("mysql").test(), ctx),
-                 dep(Dependency.builder().groupId("ch.qos.logback").artifactId("logback-classic").runtime(), ctx)]
+                 dep(Dependency.builder().groupId("org.testcontainers").artifactId("testcontainers").testImplementation(), ctx),
+                 dep(Dependency.builder().groupId("mysql").artifactId("mysql-connector-java").runtimeOnly(), ctx),
+                 dep(Dependency.builder().groupId("org.testcontainers").artifactId("junit-jupiter").testImplementation(), ctx),
+                 dep(Dependency.builder().groupId("org.testcontainers").artifactId("mysql").testImplementation(), ctx),
+                 dep(Dependency.builder().groupId("ch.qos.logback").artifactId("logback-classic").runtimeOnly(), ctx)]
 
         when:
         dependencies.sort(GradleDependency.COMPARATOR)

--- a/grails-forge-core/src/test/groovy/org/grails/forge/build/gradle/GradleSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/build/gradle/GradleSpec.groovy
@@ -34,52 +34,10 @@ class GradleSpec extends ApplicationContextSpec implements CommandOutputFixture 
 
     void "test settings.gradle"() {
         given:
-        final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
+        final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11), ["gradle-settings-file"])
         final String settingsGradle = output["settings.gradle"]
 
         expect:
-        settingsGradle.contains("pluginManagement")
-        settingsGradle.contains("repositories")
-        settingsGradle.contains("mavenLocal()")
-        settingsGradle.contains("maven { url \"https://repo.grails.org/grails/core/\" }")
-        settingsGradle.contains("gradlePluginPortal()")
-        settingsGradle.contains("id \"org.grails.grails-web\" version \"6.2.1\"")
-        settingsGradle.contains("id \"org.grails.grails-gsp\" version \"6.2.1\"")
-        settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.3.0\"")
-    }
-
-    void "test settings.gradle for REST-API"() {
-        given:
-        final def output = generate(ApplicationType.REST_API, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
-        final String settingsGradle = output["settings.gradle"]
-
-        expect:
-        settingsGradle.contains("pluginManagement")
-        settingsGradle.contains("repositories")
-        settingsGradle.contains("mavenLocal()")
-        settingsGradle.contains("maven { url \"https://repo.grails.org/grails/core/\" }")
-        settingsGradle.contains("gradlePluginPortal()")
-        settingsGradle.contains("id \"org.grails.grails-web\" version \"6.2.1\"")
-        settingsGradle.contains("id \"org.grails.plugins.views-json\" version \"3.2.3\"")
-        !settingsGradle.contains("id \"org.grails.grails-gsp\" version \"6.2.1\"")
-        !settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.3.0\"")
-    }
-
-    void "test settings.gradle for REST-API for markup-views"() {
-        given:
-        final def output = generate(ApplicationType.REST_API, new Options(TestFramework.SPOCK, JdkVersion.JDK_11), ["views-markup"])
-        final String settingsGradle = output["settings.gradle"]
-
-        expect:
-        settingsGradle.contains("pluginManagement")
-        settingsGradle.contains("repositories")
-        settingsGradle.contains("mavenLocal()")
-        settingsGradle.contains("maven { url \"https://repo.grails.org/grails/core/\" }")
-        settingsGradle.contains("gradlePluginPortal()")
-        settingsGradle.contains("id \"org.grails.grails-web\" version \"6.2.1\"")
-        settingsGradle.contains("id \"org.grails.plugins.views-markup\" version \"3.2.3\"")
-        !settingsGradle.contains("id \"org.grails.plugins.views-json\" version \"3.2.3\"")
-        !settingsGradle.contains("id \"org.grails.grails-gsp\" version \"6.2.1\"")
-        !settingsGradle.contains("id \"com.bertramlabs.asset-pipeline\" version \"4.3.0\"")
+        settingsGradle.contains("rootProject.name")
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/build/gradle/GradleSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/build/gradle/GradleSpec.groovy
@@ -40,4 +40,33 @@ class GradleSpec extends ApplicationContextSpec implements CommandOutputFixture 
         expect:
         settingsGradle.contains("rootProject.name")
     }
+
+    void "test buildSrc/build.gradle"() {
+        given:
+        def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11), ["gradle-build-src"])
+        String buildSrcGradle = output["buildSrc/build.gradle"]
+
+        expect:
+        buildSrcGradle
+        buildSrcGradle.contains('repositories')
+        buildSrcGradle.contains('dependencies')
+    }
+
+    void "no settings.gradle file is created without the 'gradle-settings-file' feature"() {
+        given:
+        def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
+        String settingsGradle = output["settings.gradle"]
+
+        expect:
+        !settingsGradle
+    }
+
+    void "no buildSrc/build.gradle file is created without the 'gradle-build-src' feature"() {
+        given:
+        def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
+        String buildSrcGradle = output["buildSrc/settings.gradle"]
+
+        expect:
+        !buildSrcGradle
+    }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/asciidoctor/AsciidoctorSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/asciidoctor/AsciidoctorSpec.groovy
@@ -22,10 +22,9 @@ class AsciidoctorSpec extends ApplicationContextSpec implements CommandOutputFix
         given:
         final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11), ["asciidoctor"])
         final def buildGradle = output["build.gradle"]
-        final def settingGradle = output["settings.gradle"]
 
         expect:
-        settingGradle.contains("id \"org.asciidoctor.jvm.convert\" version \"4.0.0-alpha.1\"")
+        buildGradle.contains("id \"org.asciidoctor.jvm.convert\" version \"4.0.0-alpha.1\"")
         buildGradle.contains("apply from: \"gradle/asciidoc.gradle\"")
     }
 

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
@@ -28,7 +28,7 @@ class AssetPipelineSpec extends ApplicationContextSpec implements CommandOutputF
 
         then:
         template.contains("id \"com.bertramlabs.asset-pipeline\"")
-        template.contains("runtimeOnly \"com.bertramlabs.plugins:asset-pipeline-grails:4.5.2\"")
+        template.contains("runtimeOnly \"com.bertramlabs.plugins:asset-pipeline-grails:4.5.1\"")
         template.contains('''
 assets {
     minifyJs = true

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
@@ -20,18 +20,6 @@ class AssetPipelineSpec extends ApplicationContextSpec implements CommandOutputF
         features.contains("asset-pipeline-grails")
     }
 
-    void "test buildSrc is present for buildscript dependencies"() {
-        given:
-        final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
-        final def buildSrcBuildGradle = output["buildSrc/build.gradle"]
-
-        expect:
-        buildSrcBuildGradle != null
-        buildSrcBuildGradle.contains("implementation(\"com.bertramlabs.plugins:asset-pipeline-gradle:4.3.0\")")
-
-    }
-
-
     void "test dependencies are present for gradle"() {
         when:
         final String template = new BuildBuilder(beanContext)
@@ -40,7 +28,7 @@ class AssetPipelineSpec extends ApplicationContextSpec implements CommandOutputF
 
         then:
         template.contains("id \"com.bertramlabs.asset-pipeline\"")
-        template.contains("runtimeOnly(\"com.bertramlabs.plugins:asset-pipeline-grails:4.3.0\")")
+        template.contains("runtimeOnly \"com.bertramlabs.plugins:asset-pipeline-grails:4.5.1\"")
         template.contains('''
 assets {
     minifyJs = true

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/assetPipeline/AssetPipelineSpec.groovy
@@ -28,7 +28,7 @@ class AssetPipelineSpec extends ApplicationContextSpec implements CommandOutputF
 
         then:
         template.contains("id \"com.bertramlabs.asset-pipeline\"")
-        template.contains("runtimeOnly \"com.bertramlabs.plugins:asset-pipeline-grails:4.5.1\"")
+        template.contains("runtimeOnly \"com.bertramlabs.plugins:asset-pipeline-grails:4.5.2\"")
         template.contains('''
 assets {
     minifyJs = true

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/cache/EHCacheSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/cache/EHCacheSpec.groovy
@@ -27,7 +27,7 @@ class EHCacheSpec extends ApplicationContextSpec implements CommandOutputFixture
                 .render()
 
         then:
-        template.contains('implementation("org.grails.plugins:cache-ehcache:3.0.0")')
+        template.contains('implementation "org.grails.plugins:cache-ehcache:3.0.0"')
 
     }
 

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/EmbeddedMongoSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/EmbeddedMongoSpec.groovy
@@ -23,7 +23,7 @@ class EmbeddedMongoSpec extends ApplicationContextSpec implements CommandOutputF
                 .render()
 
         then:
-        template.contains("testRuntimeOnly(\"org.grails.plugins:embedded-mongodb:2.0.1\")")
+        template.contains("testRuntimeOnly \"org.grails.plugins:embedded-mongodb:2.0.1\"")
     }
 
     void "test config"() {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -29,9 +29,9 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
                 .render()
 
         then:
-        template.contains('implementation("org.grails.plugins:hibernate5")')
-        template.contains("runtimeOnly(\"org.apache.tomcat:tomcat-jdbc\")")
-        template.contains("runtimeOnly(\"com.h2database:h2\")")
+        template.contains('implementation "org.grails.plugins:hibernate5"')
+        template.contains("runtimeOnly \"org.apache.tomcat:tomcat-jdbc\"")
+        template.contains("runtimeOnly \"com.h2database:h2\"")
     }
 
     void "test dependencies are present for buildSrc"() {
@@ -41,17 +41,17 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
                 .renderBuildSrc()
 
         then:
-        template.contains('implementation("org.grails.plugins:hibernate5:8.1.0")')
+        template.contains('implementation "org.grails.plugins:hibernate5:8.1.0"')
     }
 
     void "test buildSrc is present for buildscript dependencies"() {
         given:
         final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
-        final def buildSrcBuildGradle = output["buildSrc/build.gradle"]
+        final def buildGradle = output["build.gradle"]
 
         expect:
-        buildSrcBuildGradle != null
-        buildSrcBuildGradle.contains("implementation(\"org.grails.plugins:hibernate5:8.1.0\")")
+        buildGradle != null
+        buildGradle.contains("classpath \"org.grails.plugins:hibernate5:8.1.0\"")
 
     }
 

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MongoGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MongoGormSpec.groovy
@@ -41,7 +41,7 @@ class MongoGormSpec extends ApplicationContextSpec implements CommandOutputFixtu
                 .render()
 
         then:
-        template.contains("implementation(\"org.grails.plugins:mongodb\")")
+        template.contains("implementation \"org.grails.plugins:mongodb\"")
     }
 
     void "test gorm mongodb with embedded-mongodb feature"() {
@@ -51,8 +51,8 @@ class MongoGormSpec extends ApplicationContextSpec implements CommandOutputFixtu
                 .render()
 
         then:
-        template.contains("implementation(\"org.grails.plugins:mongodb\")")
-        template.contains("testRuntimeOnly(\"org.grails.plugins:embedded-mongodb:2.0.1\")")
+        template.contains("implementation \"org.grails.plugins:mongodb\"")
+        template.contains("testRuntimeOnly \"org.grails.plugins:embedded-mongodb:2.0.1\"")
     }
 
     void "test config"() {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MongoSyncSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MongoSyncSpec.groovy
@@ -33,7 +33,7 @@ class MongoSyncSpec extends ApplicationContextSpec implements CommandOutputFixtu
                 .render()
 
         then:
-        template.contains('implementation("org.mongodb:mongodb-driver-sync:4.11.3")')
-        template.contains('testImplementation("org.testcontainers:mongodb")')
+        template.contains('implementation "org.mongodb:mongodb-driver-sync:4.11.3"')
+        template.contains('testImplementation "org.testcontainers:mongodb"')
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MySQLSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MySQLSpec.groovy
@@ -13,7 +13,7 @@ class MySQLSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('runtimeOnly("mysql:mysql-connector-java")')
+        template.contains('runtimeOnly "mysql:mysql-connector-java"')
     }
 
     void "test there can only be one of DatabaseDriverFeature"() {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/Neo4JGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/Neo4JGormSpec.groovy
@@ -32,7 +32,7 @@ class Neo4JGormSpec extends ApplicationContextSpec implements CommandOutputFixtu
                 .render()
 
         then:
-        template.contains("implementation(\"org.grails.plugins:neo4j\")")
+        template.contains("implementation \"org.grails.plugins:neo4j\"")
     }
 
     void "test config"() {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/PostgresSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/PostgresSpec.groovy
@@ -13,7 +13,7 @@ class PostgresSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('runtimeOnly("org.postgresql:postgresql")')
+        template.contains('runtimeOnly "org.postgresql:postgresql"')
     }
 
     void "test there can only be one of DatabaseDriverFeature"() {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/SQLServerSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/SQLServerSpec.groovy
@@ -13,7 +13,7 @@ class SQLServerSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('runtimeOnly("com.microsoft.sqlserver:mssql-jdbc")')
+        template.contains('runtimeOnly "com.microsoft.sqlserver:mssql-jdbc"')
     }
 
     void "test there can only be one of DatabaseDriverFeature"() {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/TestContainersSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/TestContainersSpec.groovy
@@ -16,8 +16,8 @@ class TestContainersSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('testImplementation("org.testcontainers:mysql")')
-        template.contains('testImplementation("org.testcontainers:testcontainers")')
+        template.contains('testImplementation "org.testcontainers:mysql"')
+        template.contains('testImplementation "org.testcontainers:testcontainers"')
     }
 
     void "test postgres dependency is present for gradle"() {
@@ -27,8 +27,8 @@ class TestContainersSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('testImplementation("org.testcontainers:postgresql")')
-        template.contains('testImplementation("org.testcontainers:testcontainers")')
+        template.contains('testImplementation "org.testcontainers:postgresql"')
+        template.contains('testImplementation "org.testcontainers:testcontainers"')
     }
 
     void "test sqlserver dependency is present for gradle"() {
@@ -38,8 +38,8 @@ class TestContainersSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('testImplementation("org.testcontainers:mssqlserver")')
-        template.contains('testImplementation("org.testcontainers:testcontainers")')
+        template.contains('testImplementation "org.testcontainers:mssqlserver"')
+        template.contains('testImplementation "org.testcontainers:testcontainers"')
     }
 
     void "test mongo-sync dependency is present for gradle"() {
@@ -49,8 +49,8 @@ class TestContainersSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('testImplementation("org.testcontainers:mongodb")')
-        template.contains('testImplementation("org.testcontainers:testcontainers")')
+        template.contains('testImplementation "org.testcontainers:mongodb"')
+        template.contains('testImplementation "org.testcontainers:testcontainers"')
     }
 
     void "test mongo-gorm dependency is present for gradle"() {
@@ -60,8 +60,8 @@ class TestContainersSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('testImplementation("org.testcontainers:mongodb")')
-        template.contains('testImplementation("org.testcontainers:testcontainers")')
+        template.contains('testImplementation "org.testcontainers:mongodb"')
+        template.contains('testImplementation "org.testcontainers:testcontainers"')
     }
 
     void "test testcontainers core is present when no testcontainer modules are present for gradle"() {
@@ -71,7 +71,7 @@ class TestContainersSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('testImplementation("org.testcontainers:testcontainers")')
+        template.contains('testImplementation "org.testcontainers:testcontainers"')
     }
 
     void "testframework dependency is present for gradle for feature #feature and spock framework"() {
@@ -82,7 +82,7 @@ class TestContainersSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('testImplementation("org.testcontainers:spock")')
+        template.contains('testImplementation "org.testcontainers:spock"')
 
         where:
         feature << ["mongo-sync", "mysql", "postgres", "sqlserver"]
@@ -97,7 +97,7 @@ class TestContainersSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains('testImplementation("org.testcontainers:junit-jupiter")')
+        template.contains('testImplementation "org.testcontainers:junit-jupiter"')
 
         where:
         feature << ["mongo-sync", "mysql", "postgres", "sqlserver"]

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsBaseSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsBaseSpec.groovy
@@ -16,9 +16,9 @@ class GrailsBaseSpec extends BeanContextSpec implements CommandOutputFixture {
         def buildGradle = output['build.gradle']
 
         then:
-        buildGradle.contains("implementation(\"org.grails:grails-core\")")
-        buildGradle.contains("implementation(\"org.grails:grails-web-boot\")")
-        buildGradle.contains("implementation(\"org.grails:grails-logging\")")
+        buildGradle.contains("implementation \"org.grails:grails-core\"")
+        buildGradle.contains("implementation \"org.grails:grails-web-boot\"")
+        buildGradle.contains("implementation \"org.grails:grails-logging\"")
     }
 
     void "test src/main directories are present"() {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsConsoleSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsConsoleSpec.groovy
@@ -12,6 +12,6 @@ class GrailsConsoleSpec extends BeanContextSpec {
                 .render()
 
         then:
-        template.contains("console(\"org.grails:grails-console\")")
+        template.contains("console \"org.grails:grails-console\"")
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsDefaultPluginsSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsDefaultPluginsSpec.groovy
@@ -15,11 +15,11 @@ class GrailsDefaultPluginsSpec extends ApplicationContextSpec implements Command
         final String buildGradle = output["build.gradle"]
 
         expect:
-        buildGradle.contains("implementation(\"org.grails:grails-plugin-rest\")")
-        buildGradle.contains("implementation(\"org.grails:grails-plugin-databinding\")")
-        buildGradle.contains("implementation(\"org.grails:grails-plugin-i18n\")")
-        buildGradle.contains("implementation(\"org.grails:grails-plugin-services\")")
-        buildGradle.contains("implementation(\"org.grails:grails-plugin-interceptors\")")
+        buildGradle.contains("implementation \"org.grails:grails-plugin-rest\"")
+        buildGradle.contains("implementation \"org.grails:grails-plugin-databinding\"")
+        buildGradle.contains("implementation \"org.grails:grails-plugin-i18n\"")
+        buildGradle.contains("implementation \"org.grails:grails-plugin-services\"")
+        buildGradle.contains("implementation \"org.grails:grails-plugin-interceptors\"")
     }
 
     void "test i18n message properties files are present"() {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsGradlePluginSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsGradlePluginSpec.groovy
@@ -26,17 +26,17 @@ class GrailsGradlePluginSpec extends BeanContextSpec implements CommandOutputFix
                 .renderBuildSrc()
 
         then:
-        template.contains('implementation("org.grails:grails-gradle-plugin:6.2.1")')
+        template.contains('implementation "org.grails:grails-gradle-plugin:6.2.1"')
     }
 
     void "test buildSrc is present for buildscript dependencies"() {
         given:
         final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
-        final def buildSrcBuildGradle = output["buildSrc/build.gradle"]
+        final def buildGradle = output["build.gradle"]
 
         expect:
-        buildSrcBuildGradle != null
-        buildSrcBuildGradle.contains("implementation(\"org.grails:grails-gradle-plugin:6.2.1\")")
+        buildGradle != null
+        buildGradle.contains("classpath \"org.grails:grails-gradle-plugin:6.2.1\"")
 
     }
 
@@ -47,7 +47,7 @@ class GrailsGradlePluginSpec extends BeanContextSpec implements CommandOutputFix
                 .render()
 
         then:
-        template.contains("id \"org.grails.grails-plugin\"")
+        template.contains("apply plugin: \"org.grails.grails-plugin\"")
     }
 
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsWebConsoleSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsWebConsoleSpec.groovy
@@ -22,7 +22,7 @@ class GrailsWebConsoleSpec extends BeanContextSpec {
                 .render()
 
         then:
-        template.contains("runtimeOnly(\"org.grails.plugins:grails-console:2.1.1\")")
+        template.contains("runtimeOnly \"org.grails.plugins:grails-console:2.1.1\"")
     }
 
     void "test config"() {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grailsProfiles/GrailsProfilesSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grailsProfiles/GrailsProfilesSpec.groovy
@@ -2,7 +2,6 @@ package org.grails.forge.feature.grailsProfiles
 
 import org.grails.forge.ApplicationContextSpec
 import org.grails.forge.application.ApplicationType
-import org.grails.forge.application.generator.GeneratorContext
 import org.grails.forge.fixture.CommandOutputFixture
 import org.grails.forge.options.JdkVersion
 import org.grails.forge.options.Options
@@ -19,7 +18,7 @@ class GrailsProfilesSpec extends ApplicationContextSpec implements CommandOutput
         then:
         output.containsKey("build.gradle")
         def build = output.get("build.gradle")
-        build.contains("profile(\"org.grails.profiles:${applicationType.name.replace("_", "-")}\")")
+        build.contains("profile \"org.grails.profiles:${applicationType.name.replace("_", "-")}\"")
 
         where:
         applicationType << ApplicationType.values().toList()

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/lang/GrailsApplicationSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/lang/GrailsApplicationSpec.groovy
@@ -28,7 +28,7 @@ class GrailsApplicationSpec extends BeanContextSpec implements CommandOutputFixt
         def buildGradle = output['build.gradle']
 
         then:
-        buildGradle.contains('mainClass.set("example.grails.Application")')
+        buildGradle.contains('mainClass.set("example.grails.Application"')
 
         where:
         applicationType << [ApplicationType.WEB, ApplicationType.REST_API]

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/lang/GrailsApplicationSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/lang/GrailsApplicationSpec.groovy
@@ -28,7 +28,7 @@ class GrailsApplicationSpec extends BeanContextSpec implements CommandOutputFixt
         def buildGradle = output['build.gradle']
 
         then:
-        buildGradle.contains('mainClass.set("example.grails.Application"')
+        buildGradle.contains('mainClass = "example.grails.Application"')
 
         where:
         applicationType << [ApplicationType.WEB, ApplicationType.REST_API]

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/logging/LogbackGroovyConfigSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/logging/LogbackGroovyConfigSpec.groovy
@@ -16,8 +16,8 @@ class LogbackGroovyConfigSpec extends ApplicationContextSpec implements CommandO
         then:
         output.containsKey("build.gradle")
         def build = output.get("build.gradle")
-        build.contains("implementation(\"org.grails:grails-logging\")")
-        build.contains("implementation(\"io.github.virtualdogbert:logback-groovy-config:1.12.4\")")
+        build.contains("implementation \"org.grails:grails-logging\"")
+        build.contains("implementation \"io.github.virtualdogbert:logback-groovy-config:1.12.4\"")
 
         where:
         applicationType << ApplicationType.values().toList()

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/logging/LogbackSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/logging/LogbackSpec.groovy
@@ -16,7 +16,7 @@ class LogbackSpec extends ApplicationContextSpec implements CommandOutputFixture
         then:
         output.containsKey("build.gradle")
         def build = output.get("build.gradle")
-        build.contains("implementation(\"org.grails:grails-logging\")")
+        build.contains("implementation \"org.grails:grails-logging\"")
 
         where:
         applicationType << ApplicationType.values().toList()

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/micronaut/MicronautHttpClientSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/micronaut/MicronautHttpClientSpec.groovy
@@ -13,6 +13,6 @@ class MicronautHttpClientSpec extends BeanContextSpec {
                 .render()
 
         then:
-        template.contains("implementation(\"io.micronaut:micronaut-http-client\")")
+        template.contains("implementation \"io.micronaut:micronaut-http-client\"")
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/micronaut/MicronautInjectGroovySpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/micronaut/MicronautInjectGroovySpec.groovy
@@ -12,7 +12,7 @@ class MicronautInjectGroovySpec extends BeanContextSpec {
                 .render()
 
         then:
-        template.contains("compileOnly(\"io.micronaut:micronaut-inject-groovy\")")
-        template.contains("testImplementation(\"io.micronaut:micronaut-inject-groovy\")")
+        template.contains("compileOnly \"io.micronaut:micronaut-inject-groovy\"")
+        template.contains("testImplementation \"io.micronaut:micronaut-inject-groovy\"")
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/reloading/SpringBootDevToolsSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/reloading/SpringBootDevToolsSpec.groovy
@@ -24,7 +24,7 @@ class SpringBootDevToolsSpec extends ApplicationContextSpec implements CommandOu
         def build = output["build.gradle"]
 
         then:
-        build.contains("developmentOnly(\"org.springframework.boot:spring-boot-devtools\"")
+        build.contains("developmentOnly \"org.springframework.boot:spring-boot-devtools\"")
 
         where:
         applicationType << [ApplicationType.WEB, ApplicationType.REST_API]

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootSpec.groovy
@@ -20,11 +20,11 @@ class SpringBootSpec extends BeanContextSpec implements CommandOutputFixture {
         final String build = output['build.gradle']
 
         then:
-        build.contains("implementation(\"org.springframework.boot:spring-boot-starter\")")
-        build.contains("implementation(\"org.springframework.boot:spring-boot-starter-actuator\")")
-        build.contains("implementation(\"org.springframework.boot:spring-boot-starter-logging\")")
-        build.contains("implementation(\"org.springframework.boot:spring-boot-starter-validation\")")
-        build.contains("implementation(\"org.springframework.boot:spring-boot-autoconfigure\")")
+        build.contains("implementation \"org.springframework.boot:spring-boot-starter\"")
+        build.contains("implementation \"org.springframework.boot:spring-boot-starter-actuator\"")
+        build.contains("implementation \"org.springframework.boot:spring-boot-starter-logging\"")
+        build.contains("implementation \"org.springframework.boot:spring-boot-starter-validation\"")
+        build.contains("implementation \"org.springframework.boot:spring-boot-autoconfigure\"")
 
         where:
         applicationType << [ApplicationType.WEB, ApplicationType.REST_API, ApplicationType.WEB_PLUGIN]
@@ -39,11 +39,11 @@ class SpringBootSpec extends BeanContextSpec implements CommandOutputFixture {
         final String build = output['build.gradle']
 
         then:
-        !build.contains("implementation(\"org.springframework.boot:spring-boot-starter\")")
-        !build.contains("implementation(\"org.springframework.boot:spring-boot-starter-actuator\")")
-        build.contains("implementation(\"org.springframework.boot:spring-boot-starter-logging\")")
-        build.contains("implementation(\"org.springframework.boot:spring-boot-starter-validation\")")
-        build.contains("implementation(\"org.springframework.boot:spring-boot-autoconfigure\")")
-        !build.contains("implementation(\"org.springframework.boot:spring-boot-starter-tomcat\")")
+        !build.contains("implementation \"org.springframework.boot:spring-boot-starter\"")
+        !build.contains("implementation \"org.springframework.boot:spring-boot-starter-actuator\"")
+        build.contains("implementation \"org.springframework.boot:spring-boot-starter-logging\"")
+        build.contains("implementation \"org.springframework.boot:spring-boot-starter-validation\"")
+        build.contains("implementation \"org.springframework.boot:spring-boot-autoconfigure\"")
+        !build.contains("implementation \"org.springframework.boot:spring-boot-starter-tomcat\"")
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/GebSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/GebSpec.groovy
@@ -17,12 +17,12 @@ class GebSpec extends ApplicationContextSpec implements CommandOutputFixture {
         final def buildGradle = output["build.gradle"]
 
         expect:
-        buildGradle.contains("testImplementation(\"org.grails.plugins:geb\")")
-        buildGradle.contains("testImplementation(\"org.seleniumhq.selenium:selenium-api:4.19.1\")")
-        buildGradle.contains("testImplementation(\"org.seleniumhq.selenium:selenium-support:4.19.1\")")
-        buildGradle.contains("testImplementation(\"org.seleniumhq.selenium:selenium-remote-driver:4.19.1\")")
-        buildGradle.contains("testRuntimeOnly(\"org.seleniumhq.selenium:selenium-chrome-driver:4.19.1\")")
-        buildGradle.contains("testRuntimeOnly(\"org.seleniumhq.selenium:selenium-firefox-driver:4.19.1\")")
+        buildGradle.contains("testImplementation \"org.grails.plugins:geb\"")
+        buildGradle.contains("testImplementation \"org.seleniumhq.selenium:selenium-api:4.19.1\"")
+        buildGradle.contains("testImplementation \"org.seleniumhq.selenium:selenium-support:4.19.1\"")
+        buildGradle.contains("testImplementation \"org.seleniumhq.selenium:selenium-remote-driver:4.19.1\"")
+        buildGradle.contains("testRuntimeOnly \"org.seleniumhq.selenium:selenium-chrome-driver:4.19.1\"")
+        buildGradle.contains("testRuntimeOnly \"org.seleniumhq.selenium:selenium-firefox-driver:4.19.1\"")
     }
 
     void "test GebConfig.groovy file is present"() {
@@ -61,11 +61,9 @@ class GebSpec extends ApplicationContextSpec implements CommandOutputFixture {
         given:
         final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11))
         final def buildGradle = output["build.gradle"]
-        final def settingGradle = output["settings.gradle"]
 
         expect:
-        settingGradle.contains("id \"com.github.erdi.webdriver-binaries\" version \"3.2\"")
-        buildGradle.contains("id \"com.github.erdi.webdriver-binaries\"")
+        buildGradle.contains("id \"com.github.erdi.webdriver-binaries\" version \"3.2\"")
         buildGradle.contains("webdriverBinaries")
         buildGradle.contains("chromedriver '122.0.6260.0'")
         buildGradle.contains("geckodriver '0.33.0'")
@@ -76,11 +74,9 @@ class GebSpec extends ApplicationContextSpec implements CommandOutputFixture {
         given:
         final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK, JdkVersion.JDK_11, OperatingSystem.WINDOWS))
         final def buildGradle = output["build.gradle"]
-        final def settingGradle = output["settings.gradle"]
 
         expect:
-        settingGradle.contains("id \"com.github.erdi.webdriver-binaries\" version \"3.2\"")
-        buildGradle.contains("id \"com.github.erdi.webdriver-binaries\"")
+        buildGradle.contains("id \"com.github.erdi.webdriver-binaries\" version \"3.2\"")
         buildGradle.contains("webdriverBinaries")
         buildGradle.contains("chromedriver '122.0.6260.0'")
         buildGradle.contains("geckodriver '0.33.0'")

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/JUnitSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/JUnitSpec.groovy
@@ -15,6 +15,6 @@ class JUnitSpec extends ApplicationContextSpec implements CommandOutputFixture {
         final String buildGradle = output["build.gradle"]
 
         then:
-        buildGradle.contains("testImplementation(\"org.junit.jupiter:junit-jupiter")
+        buildGradle.contains("testImplementation \"org.junit.jupiter:junit-jupiter")
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/SpockSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/SpockSpec.groovy
@@ -13,7 +13,7 @@ class SpockSpec extends ApplicationContextSpec implements CommandOutputFixture {
         final String buildGradle = output["build.gradle"]
 
         then:
-        buildGradle.contains("testImplementation(\"org.spockframework:spock-core\")")
+        buildGradle.contains("testImplementation \"org.spockframework:spock-core\"")
         buildGradle.contains("useJUnitPlatform()")
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
@@ -31,7 +31,7 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
 
         then:
         template.contains("apply plugin: \"org.grails.grails-web\"")
-        template.contains("id \"org.grails.grails-gsp\"")
+        template.contains("apply plugin: \"org.grails.grails-gsp\"")
         template.contains("implementation \"org.grails.plugins:gsp\"")
     }
 

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
@@ -30,9 +30,9 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
             .render()
 
         then:
-        template.contains("id \"org.grails.grails-web\"")
+        template.contains("apply plugin: \"org.grails.grails-web\"")
         template.contains("id \"org.grails.grails-gsp\"")
-        template.contains("implementation(\"org.grails.plugins:gsp\")")
+        template.contains("implementation \"org.grails.plugins:gsp\"")
     }
 
     void "test gsp configuration"() {
@@ -87,9 +87,9 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
         final String build = output['build.gradle']
 
         then:
-        build.contains('id "org.grails.grails-web"')
-        build.contains('id "org.grails.grails-gsp"')
-        build.contains("implementation(\"org.grails.plugins:gsp\")")
+        build.contains('apply plugin: "org.grails.grails-web"')
+        build.contains('apply plugin: "org.grails.grails-gsp"')
+        build.contains("implementation \"org.grails.plugins:gsp\"")
 
         where:
         applicationType << [ApplicationType.WEB, ApplicationType.WEB_PLUGIN]
@@ -103,7 +103,7 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
 
         then:
         !build.contains('id "org.grails.grails-gsp"')
-        !build.contains("implementation(\"org.grails.plugins:gsp\")")
+        !build.contains("implementation \"org.grails.plugins:gsp\"")
 
         where:
         applicationType << [ApplicationType.PLUGIN, ApplicationType.REST_API]

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/ScaffoldingSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/ScaffoldingSpec.groovy
@@ -22,8 +22,8 @@ class ScaffoldingSpec extends ApplicationContextSpec implements CommandOutputFix
                 .render()
 
         then:
-        template.contains('implementation("org.grails.plugins:scaffolding")')
-        template.contains('runtimeOnly("org.fusesource.jansi:jansi:1.18")')
+        template.contains('implementation "org.grails.plugins:scaffolding"')
+        template.contains('runtimeOnly "org.fusesource.jansi:jansi:1.18"')
     }
 
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/json/ViewJsonSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/json/ViewJsonSpec.groovy
@@ -29,11 +29,11 @@ class ViewJsonSpec extends ApplicationContextSpec implements CommandOutputFixtur
                 .render()
 
         then:
-        template.contains("id \"org.grails.grails-web\"")
+        template.contains("apply plugin: \"org.grails.grails-web\"")
         template.contains("id \"org.grails.plugins.views-json\"")
-        template.contains("implementation(\"org.grails.plugins:views-json\"")
-        template.contains("implementation(\"org.grails.plugins:views-json-templates\"")
-        template.contains("testImplementation(\"org.grails:views-json-testing-support\"")
+        template.contains("implementation \"org.grails.plugins:views-json\"")
+        template.contains("implementation \"org.grails.plugins:views-json-templates\"")
+        template.contains("testImplementation \"org.grails:views-json-testing-support\"")
     }
 
     void "test default gson views are present"() {
@@ -55,11 +55,11 @@ class ViewJsonSpec extends ApplicationContextSpec implements CommandOutputFixtur
         final String build = output['build.gradle']
 
         then:
-        build.contains("id \"org.grails.grails-web\"")
+        build.contains("apply plugin: \"org.grails.grails-web\"")
         build.contains("id \"org.grails.plugins.views-json\"")
-        build.contains("implementation(\"org.grails.plugins:views-json\"")
-        build.contains("implementation(\"org.grails.plugins:views-json-templates\"")
-        build.contains("testImplementation(\"org.grails:views-json-testing-support\"")
+        build.contains("implementation \"org.grails.plugins:views-json\"")
+        build.contains("implementation \"org.grails.plugins:views-json-templates\"")
+        build.contains("testImplementation \"org.grails:views-json-testing-support\"")
 
         where:
         applicationType << [ApplicationType.REST_API]
@@ -73,9 +73,9 @@ class ViewJsonSpec extends ApplicationContextSpec implements CommandOutputFixtur
 
         then:
         !build.contains("id \"org.grails.plugins.views-json\"")
-        !build.contains("implementation(\"org.grails.plugins:views-json\"")
-        !build.contains("implementation(\"org.grails.plugins:views-json-templates\"")
-        !build.contains("testImplementation(\"org.grails:views-json-testing-support\"")
+        !build.contains("implementation \"org.grails.plugins:views-json\"")
+        !build.contains("implementation \"org.grails.plugins:views-json-templates\"")
+        !build.contains("testImplementation \"org.grails:views-json-testing-support\"")
 
         where:
         applicationType << [ApplicationType.WEB, ApplicationType.WEB_PLUGIN, ApplicationType.PLUGIN]

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/json/ViewMarkupSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/json/ViewMarkupSpec.groovy
@@ -27,9 +27,9 @@ class ViewMarkupSpec extends ApplicationContextSpec implements CommandOutputFixt
                 .render()
 
         then:
-        template.contains("id \"org.grails.grails-web\"")
+        template.contains("apply plugin: \"org.grails.grails-web\"")
         template.contains("id \"org.grails.plugins.views-markup\"")
-        template.contains("implementation(\"org.grails.plugins:views-markup\"")
+        template.contains("implementation \"org.grails.plugins:views-markup\"")
         !template.contains("id \"org.grails.plugins.views-json\"")
     }
 
@@ -52,12 +52,12 @@ class ViewMarkupSpec extends ApplicationContextSpec implements CommandOutputFixt
         final String build = output['build.gradle']
 
         then:
-        build.contains("id \"org.grails.grails-web\"")
+        build.contains("apply plugin: \"org.grails.grails-web\"")
         build.contains("id \"org.grails.plugins.views-markup\"")
-        build.contains("implementation(\"org.grails.plugins:views-markup\"")
+        build.contains("implementation \"org.grails.plugins:views-markup\"")
         !build.contains("id \"org.grails.plugins.views-json\"")
-        !build.contains("implementation(\"org.grails.plugins:views-json\"")
-        !build.contains("implementation(\"org.grails:views-json-testing-support\"")
+        !build.contains("implementation \"org.grails.plugins:views-json\"")
+        !build.contains("implementation \"org.grails:views-json-testing-support\"")
 
         where:
         applicationType << [ApplicationType.REST_API]

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/web/GrailsWebSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/web/GrailsWebSpec.groovy
@@ -16,7 +16,7 @@ class GrailsWebSpec extends ApplicationContextSpec implements CommandOutputFixtu
         final def buildGradle = output["build.gradle"]
 
         expect:
-        buildGradle.contains("id \"org.grails.grails-web\"")
+        buildGradle.contains("apply plugin: \"org.grails.grails-web\"")
     }
 
     void "test grails-web configuration"() {

--- a/test-core/src/test/groovy/org/grails/forge/features/scaffolding/ScaffoldingSpec.groovy
+++ b/test-core/src/test/groovy/org/grails/forge/features/scaffolding/ScaffoldingSpec.groovy
@@ -1,7 +1,5 @@
 package org.grails.forge.features.scaffolding
 
-import org.gradle.testkit.runner.BuildResult
-import org.grails.forge.options.Language
 import org.grails.forge.utils.CommandSpec
 
 class ScaffoldingSpec extends CommandSpec {
@@ -23,10 +21,14 @@ class Bird {
         final String output = executeGradle("runCommand", "-Pargs=generate-controller example.grails.Bird").getOutput()
 
         then:
-        output.contains('Rendered template Controller.groovy to destination grails-app/controllers/example/grails/BirdController.groovy')
-        output.contains('Rendered template Service.groovy to destination grails-app/services/example/grails/BirdService.groovy')
-        output.contains('Rendered template Spec.groovy to destination src/test/groovy/example/grails/BirdControllerSpec.groovy')
-        output.contains('Rendered template ServiceSpec.groovy to destination src/test/groovy/example/grails/BirdServiceSpec.groovy')
+        output.contains('Rendered template Controller.groovy to destination grails-app')
+        output.contains('BirdController.groovy')
+        output.contains('Rendered template Service.groovy to destination grails-app')
+        output.contains('BirdService.groovy')
+        output.contains('Rendered template Spec.groovy to destination src')
+        output.contains('BirdControllerSpec.groovy')
+        output.contains('Rendered template ServiceSpec.groovy to destination src')
+        output.contains('BirdServiceSpec.groovy')
         new File(dir, "grails-app/controllers/example/grails/BirdController.groovy").exists()
         new File(dir, "grails-app/services/example/grails/BirdService.groovy").exists()
         new File(dir, "src/test/groovy/example/grails/BirdControllerSpec.groovy").exists()


### PR DESCRIPTION
This was significantly more involved than anticipated.

This PR:

- Addresses the 5 linked issues
- Consolidates Gradle Plugin configuration to `buildscript{}`, `plugins{}` and `apply plugin:` in `build.gradle`
- Changes Gradle buildSrc/build.gradle and Settings File to non-default, optional features
- When the Gradle Settings File feature is selected, it only contains one line defining the root project
- When the Gradle buildSrc feature is selected `buildscript{}` is not generated, they are equivalent
- Works around https://github.com/grails/grails-gradle-plugin/issues/351 by using "apply plugin:" for Gradle plugin ids that are not published to the Gradle Plugin repo and are not release versions.  Release versions work fine with `id` and `version`.
- significant updates to fix the tests, including one that was not cross platform compatible
- adds classpath scope
- updates asset-pipeline to 4.5.1
- standardizes on double quotes with no parentheses in build.gradle, did not update web-driver/selenium since it has been removed in 7.0.x
- dependencies set to pom will still have parentheses, since they are required for platform()
- move hamcrest, micronaut-http-client and neo4j-harness dependencies to features instead of manually being set in dependencies.rocker.raw
- remove dependencies.rocker.raw since it duplicates toSnippet()
- rename RUNTIME to RUNTIME_ONLY, TEST to TEST_IMPLEMENTATION and
TEST_RUNTIME to TEST_RUNTIME_ONLY to reflect the actual Gradle scopes
- rename compile to implementation

Merging up to 7.0.x is going to be fun.