### PR TITLE
Temporarily disable docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
           asset_name: grails-cli-${{ steps.release_version.outputs.value }}.zip
           asset_content_type: application/zip
       - name: "📤 Publish to Github Pages"
+        if: false # Temp disable for re-release
         uses: micronaut-projects/github-pages-deploy-action@master
         env:
           BETA: ${{ contains(steps.release_version.outputs.value, 'M') }}


### PR DESCRIPTION
Temporary measure to get a successful release workflow with an already published version.