### PR TITLE
Revert temporary publishing adjustments and remove macOS ARM from SDKMAN releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,6 @@ jobs:
           asset_name: grails-cli-${{ steps.release_version.outputs.value }}.zip
           asset_content_type: application/zip
       - name: "📤 Publish to Github Pages"
-        if: false # Temp disable for re-release
         uses: micronaut-projects/github-pages-deploy-action@master
         env:
           BETA: ${{ contains(steps.release_version.outputs.value, 'M') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
           SECRING_FILE: ${{ secrets.SECRING_FILE }}
         run: echo $SECRING_FILE | base64 -d > ${{ github.workspace }}/secring.gpg
       - name: "📤 Publish to Sonatype OSSRH"
-        if: false # Temporary disable to prevent failure when re-running with the same version
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/grails-cli/build.gradle
+++ b/grails-cli/build.gradle
@@ -92,7 +92,6 @@ sdkman {
     version = project.version
     hashtag = "#grailsfw"
     platforms = [
-            "MAC_ARM64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-darwin-aarch64-v${project.version}.zip",
             "MAC_OSX":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-darwin-amd64-v${project.version}.zip",
             "WINDOWS_64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-win-amd64-v${project.version}.zip",
             "LINUX_64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-linux-amd64-v${project.version}.zip"


### PR DESCRIPTION
To address a failed SDKMAN publication, we temporarily disabled publishing to OSSRH since that step had already completed successfully. Additionally, documentation publishing was disabled because the documentation generation task is run in the now disabled OSSRH step.

This PR also removes the macOS ARM version from SDKMAN releases, as Java 11 no longer supports compiling to this platform.