### PR TITLE
Remove Automatic Snapshot Deployment to GCR for older versions

### DIFF
--- a/.github/workflows/mavenCentral.yml
+++ b/.github/workflows/mavenCentral.yml
@@ -30,8 +30,8 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/mavenCentral.yml
+++ b/.github/workflows/mavenCentral.yml
@@ -1,4 +1,4 @@
-name: Maven Central Sync
+name: "Maven Central Sync"
 on:
   workflow_dispatch:
     inputs:
@@ -7,31 +7,36 @@ on:
         required: true
 jobs:
   build:
-    name: Maven Central Sync
+    name: "Maven Central Sync"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
         with:
           ref: v${{ github.event.inputs.release_version }}
-      - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK
-        uses: actions/setup-java@v3.11.0
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'liberica'
           java-version: '11'
-      - name: Generate secring file
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "🔐 Generate secring file"
         env:
           SECRING_FILE: ${{ secrets.SECRING_FILE }}
         run: echo $SECRING_FILE | base64 -d > ${{ github.workspace }}/secring.gpg
-      - name: Publish to Sonatype OSSRH
-        uses: gradle/gradle-build-action@v2
+      - name: "📤 Publish to Sonatype OSSRH"
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: >
+          ./gradlew
+          -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg
+          publishToSonatype
+          closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,269 +1,276 @@
-name: Release
+name: "Release"
 on:
   release:
     types: [published]
 jobs:
   build:
-    name: Release artifacts to Bintray, Maven Central & SDKMAN, and publish documentation
+    name: "Release artifacts to Bintray, Maven Central & SDKMAN, and publish documentation"
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      release_version: ${{ steps.release_version.outputs.value }}
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-      GIT_USER_NAME: puneetbehl
-      GIT_USER_EMAIL: behlp@objectcomputing.com
+      GIT_USER_NAME: 'grails-build'
+      GIT_USER_EMAIL: 'grails-build@users.noreply.github.com'
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
-      - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
+          distribution: 'liberica'
           java-version: '11'
-      - name: Set the current release version
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "🔢 Set the current release version"
         id: release_version
-        run: echo ::set-output name=release_version::${GITHUB_REF:11}
-      - name: Run pre-release
+        run: |
+          echo "Update grailsVersion to ${GITHUB_REF:11}"
+          sed -i "s/^grailsVersion.*$/grailsVersion\=${GITHUB_REF:11}/" gradle.properties
+          sed -i "s/grailsVersion=${GITHUB_REF:11}-SNAPSHOT/grailsVersion\=${GITHUB_REF:11}/" grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsGradlePluginSpec.groovy
+          echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+      - name: "📝 Commit release version"
+        uses: stefanzweifel/git-auto-commit-action@v5.0.1
+        with:
+          commit_message: "chore: Update grailsVersion to ${{ steps.release_version.outputs.value }}"
+          commit_user_name: ${{ env.GIT_USER_NAME }}
+          commit_user_email: ${{ env.GIT_USER_EMAIL }}
+          commit_author: ${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>
+          file_pattern: .
+          branch: 6.0.x
+      - name: "⚙️ Run pre-release"
         uses: micronaut-projects/github-actions/pre-release@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build All
+      - name: "🔨 Build All"
+        env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: ./gradlew grails-cli:assemble
-
-      - name: Generate secring file
+      - name: "🔐 Generate secring file"
         env:
           SECRING_FILE: ${{ secrets.SECRING_FILE }}
         run: echo $SECRING_FILE | base64 -d > ${{ github.workspace }}/secring.gpg
-      - name: Publish to Maven Central
-        uses: gradle/gradle-build-action@v2
+      - name: "📤 Publish to Sonatype OSSRH"
         env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_NEXUS_URL: ${{ secrets.SONATYPE_NEXUS_URL }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
-        with:
-          arguments: -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg publishToSonatype closeAndReleaseSonatypeStagingRepository docs
-      - name: Upload CLI Zip
+        run: >
+          ./gradlew
+          -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg
+          publishToSonatype
+          closeSonatypeStagingRepository
+          docs
+      - name: "📤 Upload CLI Zip"
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: grails-cli/build/distributions/grails-cli-${{ steps.release_version.outputs.release_version }}.zip
-          asset_name: grails-cli-${{ steps.release_version.outputs.release_version }}.zip
+          asset_path: grails-cli/build/distributions/grails-cli-${{ steps.release_version.outputs.value }}.zip
+          asset_name: grails-cli-${{ steps.release_version.outputs.value }}.zip
           asset_content_type: application/zip
-      - name: Publish to Github Pages
-        if: success()
+      - name: "📤 Publish to Github Pages"
         uses: micronaut-projects/github-pages-deploy-action@master
         env:
-          BETA: ${{ contains(steps.release_version.outputs.release_version, 'M') || contains(steps.release_version.outputs.release_version, 'RC') }}
+          BETA: ${{ contains(steps.release_version.outputs.value, 'M') || contains(steps.release_version.outputs.release_version, 'RC') }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BASE_BRANCH: 6.0.x
           BRANCH: gh-pages
           FOLDER: build/docs
-          VERSION: ${{ steps.release_version.outputs.release_version }}
-      - name: Run post-release
+          VERSION: ${{ steps.release_version.outputs.value }}
+      - name: "⚙️ Run post-release"
         if: success()
         id: post_release
         continue-on-error: true
         uses: micronaut-projects/github-actions/post-release@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Back to snapshot
+      - name: "🔢 Back to snapshot version"
         continue-on-error: true
         run: |
           echo "Setting new Grails snapshot version"
           sed -i "s/^grailsVersion.*$/grailsVersion\=${{ steps.post_release.outputs.next_version }}-SNAPSHOT/" gradle.properties
-      - uses: stefanzweifel/git-auto-commit-action@v4.16.0
+          sed -i "s/grailsVersion=${GITHUB_REF:11}/grailsVersion\=${{ steps.post_release.outputs.next_version }}-SNAPSHOT/" grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsGradlePluginSpec.groovy
+      - name: "📝 Commit snapshot version"
+        uses: stefanzweifel/git-auto-commit-action@v5.0.1
         continue-on-error: true
         with:
-          commit_message: Back Grails version to snapshot
+          commit_message: "chore: Next snapshot version"
           commit_user_name: ${{ env.GIT_USER_NAME }}
           commit_user_email: ${{ env.GIT_USER_EMAIL }}
           commit_author: ${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>
           file_pattern: gradle.properties
   deploy:
-    name: Deploy To Google Cloud Run
+    name: "Deploy To Google Cloud Run"
     runs-on: ubuntu-latest
-    needs: [build]
-    env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+    needs: build
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set the current release version
-        id: release_version
-        run: |
-          release_version=${GITHUB_REF:11}
-          sed -i "s/^projectVersion.*$/projectVersion\=${release_version}/" gradle.properties
-          echo "release_version=${release_version}" >> $GITHUB_OUTPUT
-      - name: Login
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.build.outputs.release_version }}
+      - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_email: ${{ secrets.GCP_EMAIL }}
           service_account_key: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Configure Docker
+      - name: "🐋 Configure Docker"
         run: gcloud auth configure-docker --quiet
-      - name: Set up JDK
-        uses: actions/setup-java@v3.11.0
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'liberica'
           java-version: '11'
-      - name: Run Tests
-        uses: gradle/gradle-build-action@v2
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "✅ Run Tests"
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-api:test grails-forge-web-netty:test
-      - name: Build Docker image
+        run: >
+          ./gradlew
+          grails-forge-api:test
+          grails-forge-web-netty:test
+      - name: "🔨 Build Docker image"
         # To deploy native executables built with GraalVM replace dockerBuild with dockerBuildNative and dockerPush with dockerPushNative. First, try that it works locally.
-        uses: gradle/gradle-build-action@v2
         env:
-          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:${{ steps.release_version.outputs.release_version }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:${{ needs.build.outputs.release_version }}
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-web-netty:dockerBuildNative -PdockerImageName=${{ env.IMAGE_NAME }}
-      - name: Push image to Google Cloud Container Registry
-        uses: gradle/gradle-build-action@v2
+        run: >
+          ./gradlew
+          grails-forge-web-netty:dockerBuildNative
+          -PdockerImageName=${{ env.IMAGE_NAME }}
+      - name: "📤 Push image to Google Cloud Container Registry"
         env:
-          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:${{ steps.release_version.outputs.release_version }}
-          DEVELOVITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:${{ needs.build.outputs.release_version }}
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-web-netty:dockerPushNative -PdockerImageName=${{ env.IMAGE_NAME }}
-      - name: Deploy Docker image
+        run: >
+          ./gradlew
+          grails-forge-web-netty:dockerPushNative
+          -PdockerImageName=${{ env.IMAGE_NAME }}
+      - name: "🚀 Deploy Docker image"
         env:
-          release_version: ${{ steps.release_version.outputs.release_version }}
-          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:${{ steps.release_version.outputs.release_version }}
+          release_version: ${{ needs.build.outputs.release_version }}
+          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:${{ needs.build.outputs.release_version }}
         run: |
-          gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-latest --image $IMAGE_NAME --region us-central1 --update-env-vars=HOSTNAME="latest.grails.org",GITHUB_OAUTH_APP_CLIENT_ID=${{ secrets.GH_OAUTH_LATEST_CLIENT_ID }},GITHUB_OAUTH_APP_CLIENT_SECRET=${{ secrets.GH_OAUTH_LATEST_CLIENT_SECRET }},GITHUB_USER_AGENT=${{ secrets.GH_USER_AGENT }},GITHUB_REDIRECT_URL=${{ secrets.GH_REDIRECT_URL }} --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}
+          gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-latest --image $IMAGE_NAME --region us-central1 --update-env-vars=HOSTNAME="latest.grails.org",CORS_ALLOWED_ORIGIN="https://start.grails.org",GITHUB_OAUTH_APP_CLIENT_ID=${{ secrets.GH_OAUTH_LATEST_CLIENT_ID }},GITHUB_OAUTH_APP_CLIENT_SECRET=${{ secrets.GH_OAUTH_LATEST_CLIENT_SECRET }},GITHUB_USER_AGENT=${{ secrets.GH_USER_AGENT }},GITHUB_REDIRECT_URL=${{ secrets.GH_REDIRECT_URL }} --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}
           version="$(echo "${release_version//./}" | tr '[A-Z]' '[a-z]')"
-          gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-$version --image $IMAGE_NAME --region us-central1 --update-env-vars=HOSTNAME="grailsforge-600-cjmq3uyfcq-uc.a.run.app",GITHUB_OAUTH_APP_CLIENT_ID=${{ secrets.GH_OAUTH_LATEST_CLIENT_ID }},GITHUB_OAUTH_APP_CLIENT_SECRET=${{ secrets.GH_OAUTH_LATEST_CLIENT_SECRET }},GITHUB_USER_AGENT=${{ secrets.GH_USER_AGENT }},GITHUB_REDIRECT_URL=${{ secrets.GH_REDIRECT_URL }} --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}
+          gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-$version --image $IMAGE_NAME --region us-central1 --update-env-vars=HOSTNAME="grailsforge-600-cjmq3uyfcq-uc.a.run.app",CORS_ALLOWED_ORIGIN="https://start.grails.org",GITHUB_OAUTH_APP_CLIENT_ID=${{ secrets.GH_OAUTH_LATEST_CLIENT_ID }},GITHUB_OAUTH_APP_CLIENT_SECRET=${{ secrets.GH_OAUTH_LATEST_CLIENT_SECRET }},GITHUB_USER_AGENT=${{ secrets.GH_USER_AGENT }},GITHUB_REDIRECT_URL=${{ secrets.GH_REDIRECT_URL }} --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}
   deployanalytics:
-    name: Deploy Analytics To Google Cloud Run
+    name: "Deploy Analytics To Google Cloud Run"
     runs-on: ubuntu-latest
-    needs: [build]
-    env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+    needs: build
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set the current release version
-        id: release_version
-        run: |
-          release_version=${GITHUB_REF:11}
-          sed -i "s/^projectVersion.*$/projectVersion\=${release_version}/" gradle.properties
-          echo "release_version=${release_version}" >> $GITHUB_OUTPUT
-      - name: Login
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.build.outputs.release_version }}
+      - name: "🔑 Login"
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_email: ${{ secrets.GCP_EMAIL }}
           service_account_key: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Configure Docker
+      - name: "🐋 Configure Docker"
         run: gcloud auth configure-docker --quiet
-      - name: Set up JDK
-        uses: actions/setup-java@v3.11.0
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'liberica'
           java-version: '11'
-      - name: Run Tests
-        uses: gradle/gradle-build-action@v2
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "✅ Run Tests"
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-analytics-postgres:test
-      - name: Build Docker image
-        uses: gradle/gradle-build-action@v2
+        run: >
+          ./gradlew
+          grails-forge-analytics-postgres:test
+      - name: "🔨 Build Docker image"
         # To deploy native executables built with GraalVM replace dockerBuild with dockerBuildNative and dockerPush with dockerPushNative. First, try that it works locally.
         env:
-          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ steps.release_version.outputs.release_version }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ needs.build.outputs.release_version }}
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-analytics-postgres:dockerBuildNative -PdockerImageName=${{ env.IMAGE_NAME }}
-      - name: Push image to Google Cloud Container Registry
-        uses: gradle/gradle-build-action@v2
+        run: >
+          ./gradlew
+          grails-forge-analytics-postgres:dockerBuildNative
+          -PdockerImageName=${{ env.IMAGE_NAME }}
+      - name: "📤 Push image to Google Cloud Container Registry"
         env:
-          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ steps.release_version.outputs.release_version }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ needs.build.outputs.release_version }}
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-analytics-postgres:dockerPushNative -PdockerImageName=${{ env.IMAGE_NAME }}
-      - name: Deploy Docker image
+        run: >
+          ./gradlew
+          grails-forge-analytics-postgres:dockerPushNative
+          -PdockerImageName=${{ env.IMAGE_NAME }}
+      - name: "🚀 Deploy Docker image"
         env:
-          release_version: ${{ steps.release_version.outputs.release_version }}
-          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:${{ steps.release_version.outputs.release_version }}
+          release_version: ${{ needs.build.outputs.release_version }}
+          IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:${{ needs.build.outputs.release_version }}
         run: |
           gcloud components install beta --quiet
           gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-analytics-latest --image $IMAGE_NAME --region us-central1 --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}
           version="$(echo "${release_version//./}" | tr '[A-Z]' '[a-z]')"
           gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-analytics-$version --image $IMAGE_NAME --region us-central1 --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}
   linux:
-    name: Release Linux Native CLI
+    name: "Release Linux Native CLI"
     runs-on: ubuntu-latest
-    env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-    needs: [build]
+    needs: build
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Set the current release version
-        id: release_version
-        run: |
-          release_version=${GITHUB_REF:11}
-          sed -i "s/^projectVersion.*$/projectVersion\=${release_version}/" gradle.properties
-          echo ::set-output name=release_version::${release_version}
-      - name: Setup GraalVM CE
-        uses: graalvm/setup-graalvm@v1.0.12
+          ref: v${{ needs.build.outputs.release_version }}
+      - name: "☕️ Setup GraalVM CE"
+        uses: graalvm/setup-graalvm@v1
         with:
-          version: '21.3.3.1'
-          java-version: '11'
+          java-version: '17'
+          distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build the JAR
-        uses: gradle/gradle-build-action@v2
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
         with:
-          arguments: grails-cli:shadowJar --no-daemon
-      - name: Build Native Image
-        run: native-image --no-fallback --allow-incomplete-classpath -cp grails-cli/build/libs/grails-cli-*-all.jar
-      - name: Verify Build
-        run: ./grails --version
-      - name: Package Build
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "📸 Build the Native Image"
+        env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+        run: ./gradlew grails-cli:nativeCompile --no-daemon
+      - name: "✅ Verify Build"
+        run: ./grails-cli/build/native/nativeCompile/grails --version
+      - name: "✅ Verify Create App"
+        run: ./grails-cli/build/native/nativeCompile/grails create-app test
+      - name: "📦 Package Build"
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
           mkdir -p "grails-linux-amd64-${VERSION}/bin"
-          mv ./grails "grails-linux-amd64-${VERSION}/bin"
+          mv ./grails-cli/build/native/nativeCompile/grails "grails-linux-amd64-${VERSION}/bin"
           cp ./LICENSE "grails-linux-amd64-${VERSION}/"
           zip -r "grails-linux-amd64-${VERSION}.zip" "grails-linux-amd64-${VERSION}/"
-      - name: Upload Release Asset
+      - name: "📤 Upload Release Asset"
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
@@ -274,48 +281,43 @@ jobs:
           asset_name: grails-linux-amd64-${{ github.event.release.tag_name }}.zip
           asset_content_type: application/zip
   macos:
-    name: Release OS X Native CLI
-    runs-on: macos-latest
-    env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-    needs: [build]
+    name: "Release OS X Intel Native CLI"
+    runs-on: macos-13
+    needs: build
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Set the current release version
-        id: release_version
-        run: |
-          release_version=${GITHUB_REF:11}
-          sed -i -e "s/^projectVersion.*$/projectVersion\=${release_version}/" gradle.properties
-          echo ::set-output name=release_version::${release_version}
-      - name: Setup GraalVM CE
-        uses: graalvm/setup-graalvm@v1.0.12
+          ref: v${{ needs.build.outputs.release_version }}
+      - name: "☕️ Setup GraalVM CE"
+        uses: graalvm/setup-graalvm@v1
         with:
-          version: '21.3.3.1'
-          java-version: '11'
+          java-version: '17'
+          distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build the JAR
-        uses: gradle/gradle-build-action@v2
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
         with:
-          arguments: grails-cli:shadowJar --no-daemon
-      - name: Build Native Image
-        run: native-image --no-fallback --allow-incomplete-classpath -cp grails-cli/build/libs/grails-cli-*-all.jar
-      - name: Verify Build
-        run: ./grails --version
-      - name: Package Build
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "📸 Build the Native Image"
+        env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+        run: ./gradlew grails-cli:nativeCompile --no-daemon
+      - name: "✅ Verify Build"
+        run: ./grails-cli/build/native/nativeCompile/grails --version
+      - name: "✅ Verify Create App"
+        run: ./grails-cli/build/native/nativeCompile/grails create-app test
+      - name: "📦 Package Build"
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
           mkdir -p "grails-darwin-amd64-${VERSION}/bin"
-          mv ./grails "grails-darwin-amd64-${VERSION}/bin"
+          mv ./grails-cli/build/native/nativeCompile/grails "grails-darwin-amd64-${VERSION}/bin"
           cp ./LICENSE "grails-darwin-amd64-${VERSION}/"
           zip -r "grails-darwin-amd64-${VERSION}.zip" "grails-darwin-amd64-${VERSION}/" -x '*.DS_Store*' -x '__MAC_OSX'
-      - name: Upload Release Asset
+      - name: "📤 Upload Release Asset"
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
@@ -325,50 +327,97 @@ jobs:
           asset_path: ./grails-darwin-amd64-${{ github.event.release.tag_name }}.zip
           asset_name: grails-darwin-amd64-${{ github.event.release.tag_name }}.zip
           asset_content_type: application/zip
-  windows:
-    name: Release Windows Native CLI
-    runs-on: windows-latest
-    env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-    needs: [build]
+  macos-arm:
+    name: "Release OS X Arm Native CLI"
+    runs-on: macos-latest
+    needs: build
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Setup GraalVM CE
-        uses: graalvm/setup-graalvm@v1.0.12
+          ref: v${{ needs.build.outputs.release_version }}
+      - name: "☕️ Setup GraalVM CE"
+        uses: graalvm/setup-graalvm@v1
         with:
-          version: '21.3.3.1'
-          java-version: '11'
+          java-version: '17'
+          distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build JAR File
-        uses: gradle/gradle-build-action@v2
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
         with:
-          arguments: grails-cli:copyShadowJar --no-daemon
-      - name: Build Native Image
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "📸 Build the Native Image"
+        env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+        run: ./gradlew grails-cli:nativeCompile --no-daemon
+      - name: "✅ Verify Build"
+        run: ./grails-cli/build/native/nativeCompile/grails --version
+      - name: "✅ Verify Create App"
+        run: ./grails-cli/build/native/nativeCompile/grails create-app test
+      - name: "📦 Package Build"
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          mkdir -p "grails-darwin-aarch64-${VERSION}/bin"
+          mv ./grails-cli/build/native/nativeCompile/grails "grails-darwin-aarch64-${VERSION}/bin"
+          cp ./LICENSE "grails-darwin-aarch64-${VERSION}/"
+          zip -r "grails-darwin-aarch64-${VERSION}.zip" "grails-darwin-aarch64-${VERSION}/" -x '*.DS_Store*' -x '__MAC_OSX'
+      - name: "📤 Upload Release Asset"
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./grails-darwin-aarch64-${{ github.event.release.tag_name }}.zip
+          asset_name: grails-darwin-aarch64-${{ github.event.release.tag_name }}.zip
+          asset_content_type: application/zip
+  windows:
+    name: "Release Windows Native CLI"
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.build.outputs.release_version }}
+      - name: "☕️ Setup GraalVM CE"
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '17'
+          distribution: 'graalvm-community'
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "📸 Build the Native Image"
+        env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+        run: ./gradlew grails-cli:nativeCompile --no-daemon
+      - name: "✅ Verify Build (Powershell)"
         shell: powershell
-        run: native-image.cmd --no-fallback --allow-incomplete-classpath -cp build/libs/cli.jar
-      - name: Verify Build (Powershell)
-        run: ./grails.exe --version
-      - name: Verify Create App (Powershell)
-        run: ./grails.exe create-app test
-      - name: Verify Build (CMD)
+        run: ./grails-cli/build/native/nativeCompile/grails.exe --version
+      - name: "✅ Verify Create App (Powershell)"
+        shell: powershell
+        run: ./grails-cli/build/native/nativeCompile/grails.exe create-app test
+      - name: "✅ Verify Build (CMD)"
         shell: cmd
-        run: grails --version
-      - name: Verify Create App (CMD)
+        run: grails-cli\\build\\native\\nativeCompile\\grails --version
+      - name: "✅ Verify Create App (CMD)"
         shell: cmd
-        run: grails create-app test2
-      - name: ZIP Archive
+        run: grails-cli\\build\\native\\nativeCompile\\grails create-app test2
+      - name: "📦 ZIP Archive"
         run: |
           New-Item ./grails-win-amd64-${{ github.event.release.tag_name }}/bin -ItemType Directory -ea 0
-          Move-Item -Path ./grails.exe -Destination ./grails-win-amd64-${{ github.event.release.tag_name }}/bin
+          Move-Item -Path ./grails-cli/build/native/nativeCompile/grails.exe -Destination ./grails-win-amd64-${{ github.event.release.tag_name }}/bin
           Copy-Item ./LICENSE -Destination ./grails-win-amd64-${{ github.event.release.tag_name }}
           Compress-Archive -Path ./grails-win-amd64-${{ github.event.release.tag_name }} -Update -DestinationPath ./grails-win-amd64-${{ github.event.release.tag_name }}.zip
-      - name: Upload Release Asset
+      - name: "📤 Upload Release Asset"
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
@@ -379,37 +428,36 @@ jobs:
           asset_name: grails-win-amd64-${{ github.event.release.tag_name }}.zip
           asset_content_type: application/zip
   sdkman:
-    name: Release to SDKMAN!
+    name: "Release to SDKMAN!"
     runs-on: ubuntu-latest
-    env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-    needs: [linux, macos, windows]
+    needs: [build, linux, macos, macos-arm, windows]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Set the current release version
-        id: release_version
-        run: |
-          release_version=${GITHUB_REF:11}
-          sed -i "s/^projectVersion.*$/projectVersion\=${release_version}/" gradle.properties
-          echo ::set-output name=release_version::${release_version}
-      - name: Grails SDK Minor Release
-        if: contains(steps.release_version.outputs.release_version, 'M') || contains(steps.release_version.outputs.release_version, 'RC')
-        uses: gradle/gradle-build-action@v2
+          ref: v${{ needs.build.outputs.release_version }}
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@v4
         with:
-          arguments: sdkMinorRelease
+          distribution: 'liberica'
+          java-version: '17'
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "🚀 Grails SDK Minor Release"
+        if: contains(needs.build.outputs.release_version, 'M')
+        run: ./gradlew sdkMinorRelease
         env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
           GVM_SDKVENDOR_KEY: ${{ secrets.GVM_SDKVENDOR_KEY }}
           GVM_SDKVENDOR_TOKEN: ${{ secrets.GVM_SDKVENDOR_TOKEN }}
-      - name: Grails SDK Major Release
-        if: startsWith(steps.release_version.outputs.release_version, '6.0') && !contains(steps.release_version.outputs.release_version, 'M') && !contains(steps.release_version.outputs.release_version, 'RC')
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: sdkMajorRelease
+      - name: "🚀 Grails SDK Major Release"
+        if: startsWith(needs.build.outputs.release_version, '6.') && !contains(needs.build.outputs.release_version, 'M')
+        run: ./gradlew sdkMajorRelease
         env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
           GVM_SDKVENDOR_KEY: ${{ secrets.GVM_SDKVENDOR_KEY }}
           GVM_SDKVENDOR_TOKEN: ${{ secrets.GVM_SDKVENDOR_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
     permissions:
       contents: write
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
       GIT_USER_NAME: puneetbehl
       GIT_USER_EMAIL: behlp@objectcomputing.com
     steps:
@@ -95,9 +95,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -123,9 +123,9 @@ jobs:
       - name: Run Tests
         uses: gradle/gradle-build-action@v2
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: grails-forge-api:test grails-forge-web-netty:test
       - name: Build Docker image
@@ -133,18 +133,18 @@ jobs:
         uses: gradle/gradle-build-action@v2
         env:
           IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:${{ steps.release_version.outputs.release_version }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: grails-forge-web-netty:dockerBuildNative -PdockerImageName=${{ env.IMAGE_NAME }}
       - name: Push image to Google Cloud Container Registry
         uses: gradle/gradle-build-action@v2
         env:
           IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:${{ steps.release_version.outputs.release_version }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOVITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: grails-forge-web-netty:dockerPushNative -PdockerImageName=${{ env.IMAGE_NAME }}
       - name: Deploy Docker image
@@ -160,9 +160,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -188,9 +188,9 @@ jobs:
       - name: Run Tests
         uses: gradle/gradle-build-action@v2
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: grails-forge-analytics-postgres:test
       - name: Build Docker image
@@ -198,18 +198,18 @@ jobs:
         # To deploy native executables built with GraalVM replace dockerBuild with dockerBuildNative and dockerPush with dockerPushNative. First, try that it works locally.
         env:
           IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ steps.release_version.outputs.release_version }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: grails-forge-analytics-postgres:dockerBuildNative -PdockerImageName=${{ env.IMAGE_NAME }}
       - name: Push image to Google Cloud Container Registry
         uses: gradle/gradle-build-action@v2
         env:
           IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ steps.release_version.outputs.release_version }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: grails-forge-analytics-postgres:dockerPushNative -PdockerImageName=${{ env.IMAGE_NAME }}
       - name: Deploy Docker image
@@ -225,9 +225,9 @@ jobs:
     name: Release Linux Native CLI
     runs-on: ubuntu-latest
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
     needs: [build]
     steps:
       - name: Checkout repository
@@ -277,9 +277,9 @@ jobs:
     name: Release OS X Native CLI
     runs-on: macos-latest
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
     needs: [build]
     steps:
       - name: Checkout repository
@@ -329,9 +329,9 @@ jobs:
     name: Release Windows Native CLI
     runs-on: windows-latest
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
     needs: [build]
     steps:
       - name: Checkout repository
@@ -382,9 +382,9 @@ jobs:
     name: Release to SDKMAN!
     runs-on: ubuntu-latest
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-      GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+      DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
     needs: [linux, macos, windows]
     steps:
       - name: Checkout repository

--- a/.github/workflows/sdkman.yml
+++ b/.github/workflows/sdkman.yml
@@ -1,0 +1,39 @@
+name: "Release to SDKMan"
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+jobs:
+  sdkmanMinorRelease:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ github.event.inputs.version }}
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'liberica'
+          java-version: '17'
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "🚀 Grails SDK Minor Release"
+        run: ./gradlew sdkMinorRelease
+        env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          GVM_SDKVENDOR_KEY: ${{ secrets.GVM_SDKVENDOR_KEY }}
+          GVM_SDKVENDOR_TOKEN: ${{ secrets.GVM_SDKVENDOR_TOKEN }}
+      - name: "Set output"
+        id: set_output
+        run: |
+          echo ::set-output name=release_version::$(cat $GITHUB_OUTPUT)
+        env:
+          GITHUB_OUTPUT: ${{ github.workspace }}/build/release_version

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,9 +1,11 @@
 name: Snapshot
 on:
-  # Snapshots should only be published automatically from the latest branch
-  # as it updates the snapshot version on https://start.grails.org.
-  # However, if you need, you can still run this workflow manually for this branch on:
-  # https://github.com/grails/grails-forge/actions/workflows/snapshot.yml
+  push:
+    branches:
+      - '[6-9]+.[0-9]+.x'
+  pull_request:
+    branches:
+      - '[6-9]+.[0-9]+.x'
   workflow_dispatch:
 jobs:
   build:
@@ -60,7 +62,9 @@ jobs:
   deploy:
     name: Deploy To Google Cloud Run
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Snapshots should only be deployed from the latest release branch
+    # as it updates the snapshot version on https://start.grails.org.
+    if: false # github.event_name != 'pull_request'
     needs: [build]
     env:
       IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:snapshot
@@ -110,7 +114,9 @@ jobs:
   deployAnalytics:
     name: Deploy Analytics To Google Cloud Run
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Snapshots should only be deployed from the latest release branch
+    # as it updates the snapshot version on https://start.grails.org.
+    if: false # github.event_name != 'pull_request'
     needs: [build]
     env:
       IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}-analytics:snapshot

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,11 +1,9 @@
 name: Snapshot
 on:
-  push:
-    branches:
-      - '[6-9]+.[0-9]+.x'
-  pull_request:
-    branches:
-      - '[6-9]+.[0-9]+.x'
+  # Snapshots should only be published automatically from the latest branch
+  # as it updates the snapshot version on https://start.grails.org.
+  # However, if you need, you can still run this workflow manually for this branch on:
+  # https://github.com/grails/grails-forge/actions/workflows/snapshot.yml
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,4 +1,4 @@
-name: Snapshot
+name: "Snapshot"
 on:
   push:
     branches:
@@ -9,291 +9,328 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    name: "Build Project"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11']
+        java: ['11', '17']
     steps:
-      - uses: actions/checkout@v3.5.3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'liberica'
           java-version: ${{ matrix.java }}
-      - name: Run Tests
-        if: github.event_name == 'pull_request'
-        id: tests
-        uses: gradle/gradle-build-action@v2
-        env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
         with:
-          arguments: check
-      - name: Run Build
-        if: github.event_name == 'push'
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "🔨 Run Build"
         id: build
-        uses: gradle/gradle-build-action@v2
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: build
-      - name: Verify CLI
-        if: steps.build.outcome == 'success' && github.event_name == 'push'
+        run: ./gradlew build
+      - name: "✅ Verify CLI"
+        if: success()
         run: |
           cp grails-cli/build/distributions/grails-cli-*.zip cli.zip
           unzip cli -d tmp
           mv tmp/grails-cli-* tmp/cli
           ./tmp/cli/bin/grails --version
-      - name: Publish to Sonatype OSSRH
+      - name: "📤 Publish to Sonatype OSSRH"
         id: publish
-        if: steps.build.outcome == 'success' && github.event_name == 'push'
-        uses: gradle/gradle-build-action@v2
+        if: success() && github.event_name == 'push' && matrix.java == '11'
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: publishToSonatype
+        run: ./gradlew publishToSonatype
   deploy:
-    name: Deploy To Google Cloud Run
-    runs-on: ubuntu-latest
     # Snapshots should only be deployed from the latest release branch
     # as it updates the snapshot version on https://start.grails.org.
     if: false # github.event_name != 'pull_request'
-    needs: [build]
+    name: "Deploy To Google Cloud Run"
+    runs-on: ubuntu-latest
+    needs: build
     env:
       IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}:snapshot
     steps:
-      - name: Login
+      - name: "🔑 Login"
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_email: ${{ secrets.GCP_EMAIL }}
           service_account_key: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Configure Docker
+      - name: "🐋 Configure Docker"
         run: gcloud auth configure-docker --quiet
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3.11.0
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'liberica'
           java-version: '11'
-      - name: Run Tests
-        uses: gradle/gradle-build-action@v2
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "✅ Run Tests"
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-api:test grails-forge-web-netty:test
-      - name: Build Docker image
+        run: >
+          ./gradlew
+          grails-forge-api:test
+          grails-forge-web-netty:test
+      - name: "🔨 Build Docker image"
         # To deploy native executables built with GraalVM replace dockerBuild with dockerBuildNative and dockerPush with dockerPushNative. First, try that it works locally.
-        uses: gradle/gradle-build-action@v2
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-web-netty:dockerBuildNative -PdockerImageName=${{ env.IMAGE_NAME }}
-      - name: Push image to Google Cloud Container Registry
-        uses: gradle/gradle-build-action@v2
+        run: >
+          ./gradlew
+          grails-forge-web-netty:dockerBuildNative
+          -PdockerImageName=${{ env.IMAGE_NAME }}
+      - name: "📤 Push image to Google Cloud Container Registry"
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-web-netty:dockerPushNative -PdockerImageName=${{ env.IMAGE_NAME }}
-      - name: Deploy Docker image
-        run: gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-snapshot --image $IMAGE_NAME --region us-central1 --update-env-vars=HOSTNAME="snapshot.grails.org",GITHUB_OAUTH_APP_CLIENT_ID=${{ secrets.GH_OAUTH_SNAPSHOT_CLIENT_ID }},GITHUB_OAUTH_APP_CLIENT_SECRET=${{ secrets.GH_OAUTH_SNAPSHOT_CLIENT_SECRET }},GITHUB_USER_AGENT=${{ secrets.GH_USER_AGENT }},GITHUB_REDIRECT_URL=${{ secrets.GH_REDIRECT_URL }} --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}
+        run: >
+          ./gradlew
+          grails-forge-web-netty:dockerPushNative
+          -PdockerImageName=${{ env.IMAGE_NAME }}
+      - name: "🚀 Deploy Docker image"
+        run: >
+          gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-snapshot
+          --image $IMAGE_NAME
+          --region us-central1
+          --update-env-vars=HOSTNAME="snapshot.grails.org",CORS_ALLOWED_ORIGIN="https://start.grails.org",GITHUB_OAUTH_APP_CLIENT_ID=${{ secrets.GH_OAUTH_SNAPSHOT_CLIENT_ID }},GITHUB_OAUTH_APP_CLIENT_SECRET=${{ secrets.GH_OAUTH_SNAPSHOT_CLIENT_SECRET }},GITHUB_USER_AGENT=${{ secrets.GH_USER_AGENT }},GITHUB_REDIRECT_URL=${{ secrets.GH_REDIRECT_URL }}
+          --platform managed
+          --allow-unauthenticated
+          --service-account=${{ secrets.GCLOUD_EMAIL }}
   deployAnalytics:
-    name: Deploy Analytics To Google Cloud Run
-    runs-on: ubuntu-latest
     # Snapshots should only be deployed from the latest release branch
     # as it updates the snapshot version on https://start.grails.org.
     if: false # github.event_name != 'pull_request'
-    needs: [build]
+    name: "Deploy Analytics To Google Cloud Run"
+    runs-on: ubuntu-latest
+    needs: build
     env:
       IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}-analytics:snapshot
     steps:
-      - name: Login
+      - name: "🔑 Login"
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_email: ${{ secrets.GCP_EMAIL }}
           service_account_key: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Configure Docker
+      - name: "🐋 Configure Docker"
         run: gcloud auth configure-docker --quiet
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3.11.0
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '11'
-      - name: Run Tests
-        uses: gradle/gradle-build-action@v2
+          distribution: 'liberica'
+          java-version: '17'
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "✅ Run Tests"
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-analytics-postgres:test
-      - name: Build Docker image
-        uses: gradle/gradle-build-action@v2
+        run: ./gradlew grails-forge-analytics-postgres:test
+      - name: "🔨 Build Docker image"
         # To deploy native executables built with GraalVM replace dockerBuild with dockerBuildNative and dockerPush with dockerPushNative. First, try that it works locally.
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-analytics-postgres:dockerBuildNative -PdockerImageName=${{ env.IMAGE_NAME }}
-      - name: Push image to Google Cloud Container Registry
-        uses: gradle/gradle-build-action@v2
+        run: >
+          ./gradlew
+          grails-forge-analytics-postgres:dockerBuildNative
+          -PdockerImageName=${{ env.IMAGE_NAME }}
+      - name: "📤 Push image to Google Cloud Container Registry"
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-forge-analytics-postgres:dockerPushNative -PdockerImageName=${{ env.IMAGE_NAME }}
-      - name: Deploy Docker image
+        run: >
+          ./gradlew
+          grails-forge-analytics-postgres:dockerPushNative
+          -PdockerImageName=${{ env.IMAGE_NAME }}
+      - name: "🚀 Deploy Docker image"
         run: |
           gcloud components install beta --quiet
           gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-analytics-snapshot --image $IMAGE_NAME --region us-central1 --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}
-
   linux:
-    name: Builds Linux Native CLI
+    name: "Build Linux Native CLI"
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: build
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v3
-      - name: Setup GraalVM CE
-        uses: graalvm/setup-graalvm@v1.0.12
+      - name: "📥 Checkout the repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup GraalVM CE"
+        uses: graalvm/setup-graalvm@v1
         with:
-          version: '21.3.3.1'
-          java-version: '11'
+          java-version: '17'
+          distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build the JAR
-        uses: gradle/gradle-build-action@v2
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "📸 Build the Native Image"
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-cli:shadowJar --no-daemon
-      - name: Build Native Image
-        run: native-image --no-fallback --allow-incomplete-classpath -cp grails-cli/build/libs/grails-cli-*-all.jar
-      - name: Verify Build
-        run: ./grails --version
-      - name: Verify Create App
-        run: ./grails create-app test
-      - name: Package Build
+        run: ./gradlew grails-cli:nativeCompile --no-daemon
+      - name: "✅ Verify Build"
+        run: ./grails-cli/build/native/nativeCompile/grails --version
+      - name: "✅ Verify Create App"
+        run: ./grails-cli/build/native/nativeCompile/grails create-app test
+      - name: "📦 Package Build"
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
           mkdir -p grails-linux-amd64-snapshot/bin
-          mv ./grails grails-linux-amd64-snapshot/bin
+          mv ./grails-cli/build/native/nativeCompile/grails grails-linux-amd64-snapshot/bin
           cp ./LICENSE grails-linux-amd64-snapshot/
           zip -r grails-linux-amd64-snapshot.zip ./grails-linux-amd64-snapshot
-      - name: Upload Snapshot
+      - name: "📤 Upload Artifact to Workflow Summary Page"
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/6.0.x'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: grails-linux-amd64-snapshot
           path: grails-linux-amd64-snapshot.zip
   macos:
-    name: Builds OS X Native CLI
-    runs-on: macos-latest
-    needs: [build]
+    name: "Build OS X Intel Native CLI"
+    runs-on: macos-13
+    needs: build
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v3
-      - name: Setup GraalVM CE
-        uses: graalvm/setup-graalvm@v1.0.12
+      - name: "📥 Checkout the repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup GraalVM CE"
+        uses: graalvm/setup-graalvm@v1
         with:
-          version: '21.3.3.1'
-          java-version: '11'
+          java-version: '17'
+          distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build the JAR
-        uses: gradle/gradle-build-action@v2
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "📸 Build the Native Image"
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: grails-cli:shadowJar --no-daemon
-      - name: Build Native Image
-        run: native-image --no-fallback --allow-incomplete-classpath -cp grails-cli/build/libs/grails-cli-*-all.jar
-      - name: Verify Build
-        run: ./grails --version
-      - name: Verify Create App
-        run: ./grails create-app test
-      - name: Package Build
+        run: ./gradlew grails-cli:nativeCompile --no-daemon
+      - name: "✅ Verify Build"
+        run: ./grails-cli/build/native/nativeCompile/grails --version
+      - name: "✅ Verify Create App"
+        run: ./grails-cli/build/native/nativeCompile/grails create-app test
+      - name: "📦 Package Build"
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
           mkdir -p grails-darwin-amd64-snapshot/bin
-          mv ./grails grails-darwin-amd64-snapshot/bin
+          mv ./grails-cli/build/native/nativeCompile/grails grails-darwin-amd64-snapshot/bin
           cp ./LICENSE grails-darwin-amd64-snapshot/
           zip -r grails-darwin-amd64-snapshot.zip ./grails-darwin-amd64-snapshot -x '*.DS_Store*' -x '__MAC_OSX'
-      - name: Upload Snapshot
+      - name: "📤 Upload Artifact to Workflow Summary Page"
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/6.0.x'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: grails-darwin-amd64-snapshot
           path: grails-darwin-amd64-snapshot.zip
-  windows:
-    name: Builds Windows Native CLI
-    runs-on: windows-latest
+  macos-arm:
+    name: "Build OS X Arm Native CLI"
+    runs-on: macos-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup GraalVM CE
-        uses: graalvm/setup-graalvm@v1.0.12
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup GraalVM CE"
+        uses: graalvm/setup-graalvm@v1
         with:
-          version: '21.3.3.1'
-          java-version: '11'
+          java-version: '17'
+          distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build JAR File
-        uses: gradle/gradle-build-action@v2
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "📸 Build the Native Image"
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+        run: ./gradlew grails-cli:nativeCompile --no-daemon
+      - name: "✅ Verify Build"
+        run: ./grails-cli/build/native/nativeCompile/grails --version
+      - name: "✅ Verify Create App"
+        run: ./grails-cli/build/native/nativeCompile/grails create-app test
+      - name: "📦 Package Build"
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          mkdir -p grails-darwin-aarch64-snapshot/bin
+          mv ./grails-cli/build/native/nativeCompile/grails grails-darwin-aarch64-snapshot/bin
+          cp ./LICENSE grails-darwin-aarch64-snapshot/
+          zip -r grails-darwin-aarch64-snapshot.zip grails-darwin-aarch64-snapshot/ -x '*.DS_Store*' -x '__MAC_OSX'
+      - name: "📤 Upload Artifact to Workflow Summary Page"
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/6.0.x'
+        uses: actions/upload-artifact@v4
         with:
-          arguments: grails-cli:copyShadowJar --no-daemon
-      - name: Build Native Image
+          name: grails-darwin-aarch64-snapshot
+          path: grails-darwin-aarch64-snapshot.zip
+  windows:
+    name: "Build Windows Native CLI"
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - name: "📥 Checkout the repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup GraalVM CE"
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '17'
+          distribution: 'graalvm-community'
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "📸 Build the Native Image"
+        env:
+          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+        run: ./gradlew grails-cli:nativeCompile --no-daemon
+      - name: "✅ Verify Build (Powershell)"
         shell: powershell
-        run: native-image.cmd --no-fallback --allow-incomplete-classpath -cp build/libs/cli.jar
-      - name: Verify Build (Powershell)
+        run: ./grails-cli/build/native/nativeCompile/grails.exe --version
+      - name: "✅ Verify Create App (Powershell)"
         shell: powershell
-        run: ./grails.exe --version
-      - name: Verify Create App (Powershell)
-        run: ./grails.exe create-app test
-      - name: Verify Build (CMD)
+        run: ./grails-cli/build/native/nativeCompile/grails.exe create-app test
+      - name: "✅ Verify Build (CMD)"
         shell: cmd
-        run: grails --version
-      - name: Verify Create App (CMD)
+        run: grails-cli\\build\\native\\nativeCompile\\grails --version
+      - name: "✅ Verify Create App (CMD)"
         shell: cmd
-        run: grails create-app test2
-      - name: ZIP Archive
+        run: grails-cli\\build\\native\\nativeCompile\\grails create-app test2
+      - name: "📦 ZIP Archive"
         run: |
           New-Item "./grails-win-amd64-snapshot/bin" -ItemType Directory -ea 0
-          Move-Item -Path ./grails.exe -Destination "./grails-win-amd64-snapshot/bin"
+          Move-Item -Path ./grails-cli/build/native/nativeCompile/grails.exe -Destination "./grails-win-amd64-snapshot/bin"
           Copy-Item "./LICENSE" -Destination "./grails-win-amd64-snapshot"
           Compress-Archive -Path "./grails-win-amd64-snapshot" -Update -DestinationPath ./grails-win-amd64-snapshot.zip
-      - name: Publish artifact
+      - name: "📤 Upload Artifact to Workflow Summary Page"
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/6.0.x'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: grails-win-amd64-snapshot
           path: ./grails-win-amd64-snapshot.zip

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -43,6 +43,8 @@ jobs:
         id: publish
         if: success() && github.event_name == 'push' && matrix.java == '11'
         env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: ./gradlew publishToSonatype
@@ -70,7 +72,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'liberica'
-          java-version: '11'
+          java-version: '17'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,8 +29,8 @@ jobs:
       - name: "🔨 Run Build"
         id: build
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: ./gradlew build
       - name: "✅ Verify CLI"
         if: success()
@@ -77,8 +77,8 @@ jobs:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: "✅ Run Tests"
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: >
           ./gradlew
           grails-forge-api:test
@@ -86,16 +86,16 @@ jobs:
       - name: "🔨 Build Docker image"
         # To deploy native executables built with GraalVM replace dockerBuild with dockerBuildNative and dockerPush with dockerPushNative. First, try that it works locally.
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: >
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
       - name: "📤 Push image to Google Cloud Container Registry"
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: >
           ./gradlew
           grails-forge-web-netty:dockerPushNative
@@ -140,22 +140,22 @@ jobs:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: "✅ Run Tests"
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: ./gradlew grails-forge-analytics-postgres:test
       - name: "🔨 Build Docker image"
         # To deploy native executables built with GraalVM replace dockerBuild with dockerBuildNative and dockerPush with dockerPushNative. First, try that it works locally.
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: >
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
       - name: "📤 Push image to Google Cloud Container Registry"
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: >
           ./gradlew
           grails-forge-analytics-postgres:dockerPushNative
@@ -184,8 +184,8 @@ jobs:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: "📸 Build the Native Image"
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: ./gradlew grails-cli:nativeCompile --no-daemon
       - name: "✅ Verify Build"
         run: ./grails-cli/build/native/nativeCompile/grails --version
@@ -225,8 +225,8 @@ jobs:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: "📸 Build the Native Image"
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: ./gradlew grails-cli:nativeCompile --no-daemon
       - name: "✅ Verify Build"
         run: ./grails-cli/build/native/nativeCompile/grails --version
@@ -266,8 +266,8 @@ jobs:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: "📸 Build the Native Image"
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: ./gradlew grails-cli:nativeCompile --no-daemon
       - name: "✅ Verify Build"
         run: ./grails-cli/build/native/nativeCompile/grails --version
@@ -307,8 +307,8 @@ jobs:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: "📸 Build the Native Image"
         env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: ./gradlew grails-cli:nativeCompile --no-daemon
       - name: "✅ Verify Build (Powershell)"
         shell: powershell

--- a/grails-cli/build.gradle
+++ b/grails-cli/build.gradle
@@ -12,7 +12,7 @@ sourceSets {
 }
 
 ext {
-    picocliVersion = '4.7.4'
+    picocliVersion = '4.7.5'
 }
 
 configurations.all {
@@ -33,11 +33,11 @@ dependencies {
     api "info.picocli:picocli:${picocliVersion}"
     api "info.picocli:picocli-shell-jline3:${picocliVersion}"
     api "com.fizzed:rocker-runtime:$rockerVersion"
-    implementation "org.slf4j:slf4j-nop:2.0.7"
-    implementation "org.fusesource.jansi:jansi:2.4.0"
-    implementation "org.yaml:snakeyaml:2.0"
+    implementation "org.slf4j:slf4j-nop:2.0.16"
+    implementation "org.fusesource.jansi:jansi:2.4.1"
+    implementation "org.yaml:snakeyaml:2.2"
     implementation group: 'javax.inject', name: 'javax.inject', version: '1'
-    implementation 'org.shredzone.acme4j:acme4j-client:2.16'
+    implementation 'org.shredzone.acme4j:acme4j-client:3.2.1'
     implementation 'org.shredzone.acme4j:acme4j-utils:2.16'
     generateConfig "info.picocli:picocli-codegen:${picocliVersion}"
     compileOnly "com.google.code.findbugs:jsr305"
@@ -56,11 +56,11 @@ graalvmNative {
             sharedLibrary = false
             imageName = "grails"
             buildArgs(
-                    "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.configure=ALL-UNNAMED",
-                    "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED",
-                    "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jni=ALL-UNNAMED",
-                    "--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED",
-                    "-H:+ReportExceptionStackTraces"
+                "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.configure=ALL-UNNAMED",
+                "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED",
+                "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jni=ALL-UNNAMED",
+                "--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED",
+                "-H:+ReportExceptionStackTraces"
             )
             if (project.hasProperty("musl")) {
                 logger.lifecycle("Using musl libc")

--- a/grails-cli/build.gradle
+++ b/grails-cli/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "org.grails.forge.internal.build.cli-module"
+    id 'org.graalvm.buildtools.native' version '0.10.3'
 }
 
 sourceSets {
@@ -46,6 +47,30 @@ dependencies {
     testImplementation 'org.reflections:reflections:0.10.2'
 }
 
+graalvmNative {
+    toolchainDetection = false
+
+    binaries {
+        main {
+            // Main options
+            sharedLibrary = false
+            imageName = "grails"
+            buildArgs(
+                    "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.configure=ALL-UNNAMED",
+                    "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED",
+                    "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jni=ALL-UNNAMED",
+                    "--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED",
+                    "-H:+ReportExceptionStackTraces"
+            )
+            if (project.hasProperty("musl")) {
+                logger.lifecycle("Using musl libc")
+                buildArgs("--libc=musl", "--static")
+            }
+            mainClass = "org.grails.forge.cli.Application"
+        }
+    }
+}
+
 application {
     mainClass = "org.grails.forge.cli.Application"
 }
@@ -67,8 +92,7 @@ sdkman {
     version = project.version
     hashtag = "#grailsfw"
     platforms = [
-            // TODO:  Once graal native-image works for arm OSX, we should switch to building and publishing a non-rosetta release (https://github.com/oracle/graal/issues/2666)
-            "MAC_ARM64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-darwin-amd64-v${project.version}.zip",
+            "MAC_ARM64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-darwin-aarch64-v${project.version}.zip",
             "MAC_OSX":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-darwin-amd64-v${project.version}.zip",
             "WINDOWS_64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-win-amd64-v${project.version}.zip",
             "LINUX_64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-linux-amd64-v${project.version}.zip"

--- a/grails-cli/src/main/java/org/grails/forge/cli/CodeGenConfig.java
+++ b/grails-cli/src/main/java/org/grails/forge/cli/CodeGenConfig.java
@@ -25,10 +25,10 @@ import org.grails.forge.feature.DefaultFeature;
 import org.grails.forge.feature.Feature;
 import org.grails.forge.io.ConsoleOutput;
 import org.grails.forge.io.FileSystemOutputHandler;
+import org.grails.forge.options.JdkVersion;
 import org.grails.forge.options.Language;
 import org.grails.forge.options.Options;
 import org.grails.forge.options.TestFramework;
-import org.grails.forge.util.VersionInfo;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
@@ -149,7 +149,7 @@ public class CodeGenConfig {
                             .map(DefaultFeature.class::cast)
                             .filter(f -> f.shouldApply(
                                     codeGenConfig.getApplicationType(),
-                                    new Options(codeGenConfig.getTestFramework(), VersionInfo.getJavaVersion()),
+                                    new Options(codeGenConfig.getTestFramework(), JdkVersion.DEFAULT_OPTION),
                                     new HashSet<>()))
                             .map(Feature::getName)
                             .collect(Collectors.toList()));

--- a/grails-cli/src/main/java/org/grails/forge/cli/command/CreateCommand.java
+++ b/grails-cli/src/main/java/org/grails/forge/cli/command/CreateCommand.java
@@ -27,7 +27,6 @@ import org.grails.forge.io.FileSystemOutputHandler;
 import org.grails.forge.io.OutputHandler;
 import org.grails.forge.options.*;
 import org.grails.forge.util.NameUtils;
-import org.grails.forge.util.VersionInfo;
 import picocli.CommandLine;
 
 import java.util.Collections;
@@ -127,7 +126,7 @@ public abstract class CreateCommand extends BaseCommand implements Callable<Inte
 
     private JdkVersion getJdkVersion() {
         if (javaVersion == null) {
-            return VersionInfo.getJavaVersion();
+            return JdkVersion.DEFAULT_OPTION;
         } else {
             return JdkVersion.valueOf(javaVersion);
         }

--- a/grails-cli/src/main/java/org/grails/forge/cli/util/GrailsVersionProvider.java
+++ b/grails-cli/src/main/java/org/grails/forge/cli/util/GrailsVersionProvider.java
@@ -19,6 +19,8 @@ import jakarta.inject.Singleton;
 import org.grails.forge.util.VersionInfo;
 import picocli.CommandLine.IVersionProvider;
 
+import java.util.Objects;
+
 /**
  * Generates version information. Example usage:
  * <pre>
@@ -44,7 +46,8 @@ public class GrailsVersionProvider implements IVersionProvider {
 
     public String[] getVersion() {
         return new String[] {
-                "Grails Version: " + VersionInfo.getGrailsVersion()
+                "Grails Version: " + VersionInfo.getGrailsVersion(),
+                "JVM Version: " + Objects.requireNonNullElse(System.getProperty("java.version"), "<a valid java.home was not found>")
         };
     }
 }

--- a/grails-cli/src/test/groovy/org/grails/forge/cli/command/ApplicationCommandSpec.groovy
+++ b/grails-cli/src/test/groovy/org/grails/forge/cli/command/ApplicationCommandSpec.groovy
@@ -1,0 +1,41 @@
+package org.grails.forge.cli.command
+
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import org.grails.forge.cli.Application
+import org.grails.forge.cli.CommandFixture
+import org.grails.forge.cli.CommandSpec
+import org.grails.forge.util.VersionInfo
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+class ApplicationCommandSpec extends CommandSpec implements CommandFixture {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext ctx = ApplicationContext.run(Environment.CLI)
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext beanContext = ApplicationContext.run()
+
+    void "print version info via: grails #args"() {
+        given:
+        ByteArrayOutputStream out = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(out))
+
+        when:
+        PicocliRunner.run(Application, ctx, args)
+
+        then:
+        noExceptionThrown()
+        out.toString().contains("Grails Version: " + VersionInfo.getGrailsVersion())
+        out.toString().contains("JVM Version: " + Objects.requireNonNullElse(System.getProperty("java.version"), "<a valid java.home was not found>" ))
+
+        where:
+        args        | _
+        "--version" | _
+        "-V"        | _
+    }
+}

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/FeatureContext.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/FeatureContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,9 @@ public class FeatureContext {
         return features.stream().filter(feature -> {
             for (FeaturePredicate predicate: exclusions) {
                 if (predicate.test(feature)) {
-                    predicate.getWarning().ifPresent(message -> { throw new IllegalArgumentException(message); });
+                    predicate.getWarning().ifPresent(message -> {
+                        throw new IllegalArgumentException(message);
+                    });
                     return false;
                 }
             }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/github/workflows/templates/javaSetup.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/github/workflows/templates/javaSetup.rocker.raw
@@ -5,9 +5,9 @@
 JdkVersion jdkVersion
 )
 
-      - uses: actions/checkout@@v2
+      - uses: actions/checkout@@v4
       - name: Set up JDK @jdkVersion.majorVersion()
-        uses: actions/setup-java@@v2
+        uses: actions/setup-java@@v4
         with:
-          distribution: 'adopt'
+          distribution: 'liberica'
           java-version: @jdkVersion.majorVersion()

--- a/grails-forge-core/src/main/java/org/grails/forge/options/Options.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/options/Options.java
@@ -81,11 +81,11 @@ public class Options implements ConvertibleValues<Object> {
     }
 
     public Options(TestFramework testFramework) {
-        this(testFramework, GormImpl.DEFAULT_OPTION, ServletImpl.DEFAULT_OPTION, VersionInfo.getJavaVersion(), OperatingSystem.DEFAULT, Collections.emptyMap());
+        this(testFramework, GormImpl.DEFAULT_OPTION, ServletImpl.DEFAULT_OPTION, JdkVersion.DEFAULT_OPTION, OperatingSystem.DEFAULT, Collections.emptyMap());
     }
 
     public Options() {
-        this(TestFramework.DEFAULT_OPTION, GormImpl.DEFAULT_OPTION, ServletImpl.DEFAULT_OPTION, VersionInfo.getJavaVersion(), OperatingSystem.DEFAULT, Collections.emptyMap());
+        this(TestFramework.DEFAULT_OPTION, GormImpl.DEFAULT_OPTION, ServletImpl.DEFAULT_OPTION, JdkVersion.DEFAULT_OPTION, OperatingSystem.DEFAULT, Collections.emptyMap());
     }
 
     public OperatingSystem getOperatingSystem() {

--- a/grails-forge-core/src/main/java/org/grails/forge/options/Options.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/options/Options.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.convert.value.ConvertibleValuesMap;
 import org.grails.forge.application.OperatingSystem;
-import org.grails.forge.util.VersionInfo;
 
 import java.util.*;
 

--- a/grails-forge-core/src/main/java/org/grails/forge/util/IOFeatureUtil.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/util/IOFeatureUtil.java
@@ -49,8 +49,10 @@ public class IOFeatureUtil {
         } else {
             final String jarPath = path.toString().substring(0, sep);
             if (jarPath.endsWith(JAR_EXTENSION)) {
-                final FileSystem zipFs = FileSystems.newFileSystem(Paths.get(URI.create(jarPath)), null);
-                walkFiles(zipFs.getPath(path.toString().substring(sep + 1)), classLoader, addTemplate);
+                ClassLoader loader = null;
+                try (FileSystem zipFs = FileSystems.newFileSystem(Paths.get(URI.create(jarPath)), loader)) {
+                    walkFiles(zipFs.getPath(path.toString().substring(sep + 1)), classLoader, addTemplate);
+                }
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,34 +10,36 @@ buildscript {
     }
 }
 plugins {
-    id "com.gradle.enterprise" version "3.14"
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11.1'
+    id "com.gradle.develocity" version "3.18.2"
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
-gradleEnterprise {
+def isCI = System.getenv('CI') != null
+def isLocal = !isCI
+def isAuthenticated = System.getenv('DEVELOCITY_ACCESS_KEY') != null
+def isBuildCacheAuthenticated =
+        System.getenv('DEVELOCITY_BUILD_CACHE_NODE_USER') != null &&
+        System.getenv('DEVELOCITY_BUILD_CACHE_NODE_KEY') != null
+
+develocity {
     server = 'https://ge.grails.org'
     buildScan {
-        publishAlways()
-        publishIfAuthenticated()
-        uploadInBackground = System.getenv("CI") == null
-        capture {
-            taskInputFiles = true
-        }
+        publishing.onlyIf { isAuthenticated }
+        uploadInBackground = isLocal
     }
 }
 
 buildCache {
-    local { enabled = System.getenv('CI') != 'true' }
-    remote(HttpBuildCache) {
-        push = System.getenv('CI') == 'true'
+    local { enabled = isLocal }
+    remote(develocity.buildCache) {
+        push = isCI && isBuildCacheAuthenticated
         enabled = true
-        url = 'https://ge.grails.org/cache/'
-        credentials {
-            username = System.getenv('GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER')
-            password = System.getenv('GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY')
-        }
-    }}
-
+        usernameAndPassword(
+                System.getenv('DEVELOCITY_BUILD_CACHE_NODE_USER') ?: '',
+                System.getenv('DEVELOCITY_BUILD_CACHE_NODE_KEY') ?: ''
+        )
+    }
+}
 
 rootProject.name = 'grails-forge'
 


### PR DESCRIPTION
Only the latest release branch should automatically deploy snapshots to https://start.grails.org.