### PR TITLE
Remove space before `testFixtures` parentheses

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleDependency.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleDependency.java
@@ -101,7 +101,8 @@ public class GradleDependency extends DependencyCoordinate {
 
     @NonNull
     public String toSnippet() {
-        String snippet = gradleConfiguration.getConfigurationName() + " ";
+        String optionalSpace = gradleConfiguration == INTEGRATION_TEST_IMPLEMENTATION_TEST_FIXTURES ? "" : " ";
+        String snippet = gradleConfiguration.getConfigurationName() + optionalSpace;
         if (isPom()) {
             snippet += "platform(";
         } else if (gradleConfiguration == INTEGRATION_TEST_IMPLEMENTATION_TEST_FIXTURES) {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/GebWithTestcontainersSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/GebWithTestcontainersSpec.groovy
@@ -15,7 +15,7 @@ class GebWithTestcontainersSpec extends ApplicationContextSpec implements Comman
         def buildGradle = output['build.gradle']
 
         expect:
-        buildGradle.contains('integrationTestImplementation testFixtures ("org.grails.plugins:geb")')
+        buildGradle.contains('integrationTestImplementation testFixtures("org.grails.plugins:geb")')
     }
 
     @Unroll

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/GebWithWebDriverBinariesSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/test/GebWithWebDriverBinariesSpec.groovy
@@ -16,7 +16,7 @@ class GebWithWebDriverBinariesSpec extends ApplicationContextSpec implements Com
         def buildGradle = output['build.gradle']
 
         expect:
-        buildGradle.contains('integrationTestImplementation testFixtures ("org.grails.plugins:geb")')
+        buildGradle.contains('integrationTestImplementation testFixtures("org.grails.plugins:geb")')
         buildGradle.contains('testImplementation "org.seleniumhq.selenium:selenium-api"')
         buildGradle.contains('testImplementation "org.seleniumhq.selenium:selenium-support"')
         buildGradle.contains('testImplementation "org.seleniumhq.selenium:selenium-remote-driver"')


### PR DESCRIPTION
The `testFixtures` method call should not have a space before the parentheses to adhere to proper syntax.