### PR TITLE
change native binaries, sdkman candidates & release assets from grails to grailsforge

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -79,16 +79,16 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          mkdir -p grails-linux-amd64-snapshot/bin
-          mv ./grails-cli/build/native/nativeCompile/grails grails-linux-amd64-snapshot/bin
-          cp ./LICENSE grails-linux-amd64-snapshot/
-          zip -r grails-linux-amd64-snapshot.zip ./grails-linux-amd64-snapshot
+          mkdir -p grailsforge-linux-amd64-snapshot/bin
+          mv ./grails-cli/build/native/nativeCompile/grails grailsforge-linux-amd64-snapshot/bin
+          cp ./LICENSE grailsforge-linux-amd64-snapshot/
+          zip -r grailsforge-linux-amd64-snapshot.zip ./grailsforge-linux-amd64-snapshot
       - name: "📤 Upload Artifact to Workflow Summary Page"
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/7.0.x'
         uses: actions/upload-artifact@v4
         with:
-          name: grails-linux-amd64-snapshot
-          path: grails-linux-amd64-snapshot.zip
+          name: grailsforge-linux-amd64-snapshot
+          path: grailsforge-linux-amd64-snapshot.zip
   macos:
     name: "Build OS X Intel Native CLI"
     runs-on: macos-13
@@ -120,16 +120,16 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          mkdir -p grails-darwin-amd64-snapshot/bin
-          mv ./grails-cli/build/native/nativeCompile/grails grails-darwin-amd64-snapshot/bin
-          cp ./LICENSE grails-darwin-amd64-snapshot/
-          zip -r grails-darwin-amd64-snapshot.zip ./grails-darwin-amd64-snapshot -x '*.DS_Store*' -x '__MAC_OSX'
+          mkdir -p grailsforge-darwin-amd64-snapshot/bin
+          mv ./grails-cli/build/native/nativeCompile/grails grailsforge-darwin-amd64-snapshot/bin
+          cp ./LICENSE grailsforge-darwin-amd64-snapshot/
+          zip -r grailsforge-darwin-amd64-snapshot.zip ./grailsforge-darwin-amd64-snapshot -x '*.DS_Store*' -x '__MAC_OSX'
       - name: "📤 Upload Artifact to Workflow Summary Page"
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/7.0.x'
         uses: actions/upload-artifact@v4
         with:
-          name: grails-darwin-amd64-snapshot
-          path: grails-darwin-amd64-snapshot.zip
+          name: grailsforge-darwin-amd64-snapshot
+          path: grailsforge-darwin-amd64-snapshot.zip
   macos-arm:
     name: "Build OS X Arm Native CLI"
     runs-on: macos-latest
@@ -161,16 +161,16 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          mkdir -p grails-darwin-aarch64-snapshot/bin
-          mv ./grails-cli/build/native/nativeCompile/grails grails-darwin-aarch64-snapshot/bin
-          cp ./LICENSE grails-darwin-aarch64-snapshot/
-          zip -r grails-darwin-aarch64-snapshot.zip grails-darwin-aarch64-snapshot/ -x '*.DS_Store*' -x '__MAC_OSX'
+          mkdir -p grailsforge-darwin-aarch64-snapshot/bin
+          mv ./grails-cli/build/native/nativeCompile/grails grailsforge-darwin-aarch64-snapshot/bin
+          cp ./LICENSE grailsforge-darwin-aarch64-snapshot/
+          zip -r grailsforge-darwin-aarch64-snapshot.zip grailsforge-darwin-aarch64-snapshot/ -x '*.DS_Store*' -x '__MAC_OSX'
       - name: "📤 Upload Artifact to Workflow Summary Page"
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/7.0.x'
         uses: actions/upload-artifact@v4
         with:
-          name: grails-darwin-aarch64-snapshot
-          path: grails-darwin-aarch64-snapshot.zip
+          name: grailsforge-darwin-aarch64-snapshot
+          path: grailsforge-darwin-aarch64-snapshot.zip
   windows:
     name: "Build Windows Native CLI"
     runs-on: windows-latest
@@ -208,13 +208,13 @@ jobs:
         run: grails-cli\\build\\native\\nativeCompile\\grails create-app test2
       - name: "📦 ZIP Archive"
         run: |
-          New-Item "./grails-win-amd64-snapshot/bin" -ItemType Directory -ea 0
-          Move-Item -Path ./grails-cli/build/native/nativeCompile/grails.exe -Destination "./grails-win-amd64-snapshot/bin"
-          Copy-Item "./LICENSE" -Destination "./grails-win-amd64-snapshot"
-          Compress-Archive -Path "./grails-win-amd64-snapshot" -Update -DestinationPath ./grails-win-amd64-snapshot.zip
+          New-Item "./grailsforge-win-amd64-snapshot/bin" -ItemType Directory -ea 0
+          Move-Item -Path ./grails-cli/build/native/nativeCompile/grails.exe -Destination "./grailsforge-win-amd64-snapshot/bin"
+          Copy-Item "./LICENSE" -Destination "./grailsforge-win-amd64-snapshot"
+          Compress-Archive -Path "./grailsforge-win-amd64-snapshot" -Update -DestinationPath ./grailsforge-win-amd64-snapshot.zip
       - name: "📤 Upload Artifact to Workflow Summary Page"
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/7.0.x'
         uses: actions/upload-artifact@v4
         with:
-          name: grails-win-amd64-snapshot
-          path: ./grails-win-amd64-snapshot.zip
+          name: grailsforge-win-amd64-snapshot
+          path: ./grailsforge-win-amd64-snapshot.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,10 +142,10 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          mkdir -p "grails-linux-amd64-${VERSION}/bin"
-          mv ./grails-cli/build/native/nativeCompile/grails "grails-linux-amd64-${VERSION}/bin"
-          cp ./LICENSE "grails-linux-amd64-${VERSION}/"
-          zip -r "grails-linux-amd64-${VERSION}.zip" "grails-linux-amd64-${VERSION}/"
+          mkdir -p "grailsforge-linux-amd64-${VERSION}/bin"
+          mv ./grails-cli/build/native/nativeCompile/grails "grailsforge-linux-amd64-${VERSION}/bin"
+          cp ./LICENSE "grailsforge-linux-amd64-${VERSION}/"
+          zip -r "grailsforge-linux-amd64-${VERSION}.zip" "grailsforge-linux-amd64-${VERSION}/"
       - name: "📤 Upload Release Asset"
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -153,8 +153,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./grails-linux-amd64-${{ github.event.release.tag_name }}.zip
-          asset_name: grails-linux-amd64-${{ github.event.release.tag_name }}.zip
+          asset_path: ./grailsforge-linux-amd64-${{ github.event.release.tag_name }}.zip
+          asset_name: grailsforge-linux-amd64-${{ github.event.release.tag_name }}.zip
           asset_content_type: application/zip
   macos:
     name: "Release OS X Intel Native CLI"
@@ -189,10 +189,10 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          mkdir -p "grails-darwin-amd64-${VERSION}/bin"
-          mv ./grails-cli/build/native/nativeCompile/grails "grails-darwin-amd64-${VERSION}/bin"
-          cp ./LICENSE "grails-darwin-amd64-${VERSION}/"
-          zip -r "grails-darwin-amd64-${VERSION}.zip" "grails-darwin-amd64-${VERSION}/" -x '*.DS_Store*' -x '__MAC_OSX'
+          mkdir -p "grailsforge-darwin-amd64-${VERSION}/bin"
+          mv ./grails-cli/build/native/nativeCompile/grails "grailsforge-darwin-amd64-${VERSION}/bin"
+          cp ./LICENSE "grailsforge-darwin-amd64-${VERSION}/"
+          zip -r "grailsforge-darwin-amd64-${VERSION}.zip" "grailsforge-darwin-amd64-${VERSION}/" -x '*.DS_Store*' -x '__MAC_OSX'
       - name: "📤 Upload Release Asset"
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -200,8 +200,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./grails-darwin-amd64-${{ github.event.release.tag_name }}.zip
-          asset_name: grails-darwin-amd64-${{ github.event.release.tag_name }}.zip
+          asset_path: ./grailsforge-darwin-amd64-${{ github.event.release.tag_name }}.zip
+          asset_name: grailsforge-darwin-amd64-${{ github.event.release.tag_name }}.zip
           asset_content_type: application/zip
   macos-arm:
     name: "Release OS X Arm Native CLI"
@@ -236,10 +236,10 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          mkdir -p "grails-darwin-aarch64-${VERSION}/bin"
-          mv ./grails-cli/build/native/nativeCompile/grails "grails-darwin-aarch64-${VERSION}/bin"
-          cp ./LICENSE "grails-darwin-aarch64-${VERSION}/"
-          zip -r "grails-darwin-aarch64-${VERSION}.zip" "grails-darwin-aarch64-${VERSION}/" -x '*.DS_Store*' -x '__MAC_OSX'
+          mkdir -p "grailsforge-darwin-aarch64-${VERSION}/bin"
+          mv ./grails-cli/build/native/nativeCompile/grails "grailsforge-darwin-aarch64-${VERSION}/bin"
+          cp ./LICENSE "grailsforge-darwin-aarch64-${VERSION}/"
+          zip -r "grailsforge-darwin-aarch64-${VERSION}.zip" "grailsforge-darwin-aarch64-${VERSION}/" -x '*.DS_Store*' -x '__MAC_OSX'
       - name: "📤 Upload Release Asset"
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -247,8 +247,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./grails-darwin-aarch64-${{ github.event.release.tag_name }}.zip
-          asset_name: grails-darwin-aarch64-${{ github.event.release.tag_name }}.zip
+          asset_path: ./grailsforge-darwin-aarch64-${{ github.event.release.tag_name }}.zip
+          asset_name: grailsforge-darwin-aarch64-${{ github.event.release.tag_name }}.zip
           asset_content_type: application/zip
   windows:
     name: "Release Windows Native CLI"
@@ -289,10 +289,10 @@ jobs:
         run: grails-cli\\build\\native\\nativeCompile\\grails create-app test2
       - name: "📦 ZIP Archive"
         run: |
-          New-Item ./grails-win-amd64-${{ github.event.release.tag_name }}/bin -ItemType Directory -ea 0
-          Move-Item -Path ./grails-cli/build/native/nativeCompile/grails.exe -Destination ./grails-win-amd64-${{ github.event.release.tag_name }}/bin
-          Copy-Item ./LICENSE -Destination ./grails-win-amd64-${{ github.event.release.tag_name }}
-          Compress-Archive -Path ./grails-win-amd64-${{ github.event.release.tag_name }} -Update -DestinationPath ./grails-win-amd64-${{ github.event.release.tag_name }}.zip
+          New-Item ./grailsforge-win-amd64-${{ github.event.release.tag_name }}/bin -ItemType Directory -ea 0
+          Move-Item -Path ./grails-cli/build/native/nativeCompile/grails.exe -Destination ./grailsforge-win-amd64-${{ github.event.release.tag_name }}/bin
+          Copy-Item ./LICENSE -Destination ./grailsforge-win-amd64-${{ github.event.release.tag_name }}
+          Compress-Archive -Path ./grailsforge-win-amd64-${{ github.event.release.tag_name }} -Update -DestinationPath ./grailsforge-win-amd64-${{ github.event.release.tag_name }}.zip
       - name: "📤 Upload Release Asset"
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -300,8 +300,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./grails-win-amd64-${{ github.event.release.tag_name }}.zip
-          asset_name: grails-win-amd64-${{ github.event.release.tag_name }}.zip
+          asset_path: ./grailsforge-win-amd64-${{ github.event.release.tag_name }}.zip
+          asset_name: grailsforge-win-amd64-${{ github.event.release.tag_name }}.zip
           asset_content_type: application/zip
   sdkman:
     name: "Release to SDKMAN!"

--- a/grails-cli/build.gradle
+++ b/grails-cli/build.gradle
@@ -87,13 +87,13 @@ sdkman {
     api = "https://vendors.sdkman.io"
     consumerKey = System.getenv("GVM_SDKVENDOR_KEY") ?: project.hasProperty("gvmSdkvendorKey") ? project.gvmSdkvendorKey : ''
     consumerToken = System.getenv("GVM_SDKVENDOR_TOKEN") ?: project.hasProperty("gvmSdkvendorToken") ? project.gvmSdkvendorToken : ''
-    candidate = "grails"
+    candidate = "grailsforge"
     version = project.version
-    hashtag = "#grailsfw"
+    hashtag = "#grailsforge"
     platforms = [
-            "MAC_ARM64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-darwin-aarch64-v${project.version}.zip",
-            "MAC_OSX":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-darwin-amd64-v${project.version}.zip",
-            "WINDOWS_64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-win-amd64-v${project.version}.zip",
-            "LINUX_64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grails-linux-amd64-v${project.version}.zip"
+            "MAC_ARM64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grailsforge-darwin-aarch64-v${project.version}.zip",
+            "MAC_OSX":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grailsforge-darwin-amd64-v${project.version}.zip",
+            "WINDOWS_64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grailsforge-win-amd64-v${project.version}.zip",
+            "LINUX_64":"https://github.com/grails/grails-forge/releases/download/v${project.version}/grailsforge-linux-amd64-v${project.version}.zip"
     ]
 }

--- a/grails-cli/src/main/resources/META-INF/native-image/org.grails.forge.cli/grails-forge-cli/native-image.properties
+++ b/grails-cli/src/main/resources/META-INF/native-image/org.grails.forge.cli/grails-forge-cli/native-image.properties
@@ -1,2 +1,2 @@
-Args = -H:Name=grails \
+Args = -H:Name=grailsforge \
        -H:Class=org.grails.forge.cli.Application


### PR DESCRIPTION
The new SDKMAN candidate `grailsforge` may need to be configured in SDKMAN.  

This changes the filenames for the GitHub release also, for clarity.  

More changes might be required, this is a start.