### PR TITLE
Clean up `Application.groovy` imports

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/lang/groovy/application.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/lang/groovy/application.rocker.raw
@@ -8,15 +8,15 @@ package @project.getPackageName()
 
 import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
-import groovy.transform.CompileStatic
-import grails.plugins.metadata.*
-
-@if(applicationType.equals(ApplicationType.WEB) || applicationType.equals(ApplicationType.REST_API)) {
-@@CompileStatic
+@if(applicationType.equals(ApplicationType.PLUGIN) || applicationType.equals(ApplicationType.WEB_PLUGIN)) {
+import grails.plugins.metadata.PluginSource
 }
+import groovy.transform.CompileStatic
+
 @if(applicationType.equals(ApplicationType.PLUGIN) || applicationType.equals(ApplicationType.WEB_PLUGIN)) {
 @@PluginSource
 }
+@@CompileStatic
 class Application extends GrailsAutoConfiguration {
     static void main(String[] args) {
         GrailsApp.run(Application, args)

--- a/test-core/src/test/groovy/org/grails/forge/create/CreateAppSpec.groovy
+++ b/test-core/src/test/groovy/org/grails/forge/create/CreateAppSpec.groovy
@@ -1,5 +1,6 @@
 package org.grails.forge.create
 
+import org.grails.forge.application.ApplicationType
 import org.grails.forge.application.OperatingSystem
 import org.grails.forge.utils.CommandSpec
 
@@ -36,6 +37,55 @@ class CreateAppSpec extends CommandSpec {
 
         expect:
         new File(dir, "grails-app/i18n").exists()
+    }
+
+    void "test create-app creates a correct Application.groovy"() {
+        given:
+        generateProject(OperatingSystem.MACOS_ARCH64, [], ApplicationType.DEFAULT_OPTION)
+        def applicationClassSourceFile = new File(dir, 'grails-app/init/example/grails/Application.groovy')
+
+        expect:
+        applicationClassSourceFile.exists()
+        applicationClassSourceFile.text == '''\
+        package example.grails
+        
+        import grails.boot.GrailsApp
+        import grails.boot.config.GrailsAutoConfiguration
+        import groovy.transform.CompileStatic
+        
+        @CompileStatic
+        class Application extends GrailsAutoConfiguration {
+            static void main(String[] args) {
+                GrailsApp.run(Application, args)
+            }
+        }
+        '''.stripIndent(8)
+    }
+
+    void "test create-app web-plugin creates a correct Application.groovy"() {
+        given:
+        generateProject(OperatingSystem.MACOS_ARCH64, [], ApplicationType.WEB_PLUGIN)
+
+        def applicationClassSourceFile = new File(dir, 'grails-app/init/example/grails/Application.groovy')
+
+        expect:
+        applicationClassSourceFile.exists()
+        applicationClassSourceFile.text == '''\
+        package example.grails
+        
+        import grails.boot.GrailsApp
+        import grails.boot.config.GrailsAutoConfiguration
+        import grails.plugins.metadata.PluginSource
+        import groovy.transform.CompileStatic
+        
+        @PluginSource
+        @CompileStatic
+        class Application extends GrailsAutoConfiguration {
+            static void main(String[] args) {
+                GrailsApp.run(Application, args)
+            }
+        }
+        '''.stripIndent(8)
     }
 
     @Override


### PR DESCRIPTION
- Replace star import for `PluginSource` with an explicit import.
- Restrict `PluginSource` import to plugin projects only.
- Always add `@CompileStatic`.