### PR TITLE
exclude org.graalvm dependencies from the deployable war/jar

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -72,12 +72,16 @@ repositories {
 
 @dependencies.template(applicationType, project, features, gradleBuild)
 
+@if(features.contains("asset-pipeline-grails")) {
 // exclude org.graalvm dependencies which are required by asset-pipeline-core
 // for bootRun but are not required in the deployed war/jar
+// see:  https://github.com/grails/grails-core/pull/13971
 tasks.named { it in ['bootWar', 'bootJar', 'war'] }.configureEach {
     classpath = classpath.findAll {
         !it.toString().contains('org.graalvm.')
     }
+}
+
 }
 
 @if(features.contains("geb-with-webdriver-binaries")) {

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -72,6 +72,14 @@ repositories {
 
 @dependencies.template(applicationType, project, features, gradleBuild)
 
+// exclude org.graalvm dependencies which are required by asset-pipeline-core
+// for bootRun but are not required in the deployed war/jar
+tasks.named { it in ['bootWar', 'bootJar', 'war'] }.configureEach {
+    classpath = classpath.findAll {
+        !it.toString().contains('org.graalvm.')
+    }
+}
+
 @if(features.contains("geb-with-webdriver-binaries")) {
 // geb-with-webdriver-binaries is limited to Gradle 8.6 with max JDK 21
 compileJava.options.release = @JdkVersion.valueOf(Math.min(features.javaVersion().majorVersion(), JdkVersion.JDK_21.majorVersion())).majorVersion()


### PR DESCRIPTION
exclude org.graalvm dependencies which are required by asset-pipeline-core for bootRun but are not required in the deployed war/jar