### PR TITLE
Use versions from grails-bom in additional locations

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/asciidoctor/Asciidoctor.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/asciidoctor/Asciidoctor.java
@@ -54,9 +54,9 @@ public class Asciidoctor implements Feature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         final String asciidoctorjVersion = coordinateResolver.resolve("asciidoctorj")
-                .map(Coordinate::getVersion).orElse("2.1.0");
+                .map(Coordinate::getVersion).orElse("3.0.0");
         final String asciidoctorjDiagramVersion = coordinateResolver.resolve("asciidoctorj-diagram")
-                .map(Coordinate::getVersion).orElse("1.5.18");
+                .map(Coordinate::getVersion).orElse("2.3.1");
         generatorContext.addTemplate("asciidocGradle", new RockerTemplate("gradle/asciidoc.gradle", asciidocGradle.template(asciidoctorjVersion, asciidoctorjDiagramVersion)));
 
         generatorContext.addBuildPlugin(GradlePlugin.builder()

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
@@ -29,6 +29,7 @@ import org.grails.forge.feature.assetPipeline.templates.assetPipelineExtension;
 import org.grails.forge.options.Options;
 import org.grails.forge.template.RockerWritable;
 import org.grails.forge.template.URLTemplate;
+import org.grails.forge.util.VersionInfo;
 
 import java.util.Set;
 
@@ -63,8 +64,10 @@ public class AssetPipeline implements DefaultFeature {
         generatorContext.addBuildPlugin(GradlePlugin.builder()
                 .id("com.bertramlabs.asset-pipeline")
                 .extension(new RockerWritable(assetPipelineExtension.template(generatorContext.getApplicationType())))
-                .lookupArtifactId("asset-pipeline-gradle")
+                .version("$assetPipelineGradleVersion")
                 .build());
+
+        generatorContext.getBuildProperties().put("assetPipelineGradleVersion", VersionInfo.getBomVersion("asset-pipeline-gradle"));
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("com.bertramlabs.plugins")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/cache/GrailsCache.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/cache/GrailsCache.java
@@ -50,7 +50,7 @@ public class GrailsCache implements Feature {
         config.put("grails.cache.cacheManager", "grails.plugin.cache.GrailsConcurrentMapCacheManager");
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
-                .lookupArtifactId("cache")
+                .artifactId("cache")
                 .implementation());
     }
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -81,7 +81,7 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
 
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
-                .lookupArtifactId("hibernate5")
+                .artifactId("hibernate5")
                 .buildSrc());
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/MongoSync.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/MongoSync.java
@@ -51,7 +51,7 @@ public class MongoSync extends MongoFeature {
         config.put("grails.mongodb.url", "mongodb://${MONGO_HOST:localhost}:${MONGO_PORT:27017}/foo");
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.mongodb")
-                .lookupArtifactId("mongodb-driver-sync")
+                .artifactId("mongodb-driver-sync")
                 .implementation()
         );
     }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsBase.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsBase.java
@@ -60,6 +60,13 @@ public class GrailsBase implements DefaultFeature {
                 .version("$grailsVersion")
                 .implementation());
 
+        generatorContext.addBuildscriptDependency(Dependency.builder()
+                .groupId("org.grails")
+                .artifactId("grails-bom")
+                .pom(true)
+                .version("$grailsVersion")
+                .classpath());
+
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails")
                 .artifactId("grails-core")

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsGradlePlugin.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsGradlePlugin.java
@@ -18,16 +18,15 @@ package org.grails.forge.feature.grails;
 import jakarta.inject.Singleton;
 import org.grails.forge.application.ApplicationType;
 import org.grails.forge.application.generator.GeneratorContext;
-import org.grails.forge.build.dependencies.Coordinate;
 import org.grails.forge.build.dependencies.CoordinateResolver;
 import org.grails.forge.build.dependencies.Dependency;
-import org.grails.forge.build.dependencies.LookupFailedException;
 import org.grails.forge.build.gradle.GradlePlugin;
 import org.grails.forge.feature.DefaultFeature;
 import org.grails.forge.feature.Feature;
 import org.grails.forge.feature.view.GrailsGsp;
 import org.grails.forge.feature.web.GrailsWeb;
 import org.grails.forge.options.Options;
+import org.grails.forge.util.VersionInfo;
 
 import java.util.Set;
 
@@ -62,22 +61,22 @@ class GrailsGradlePlugin implements DefaultFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        final String artifactId = "grails-gradle-plugin";
-        final Coordinate grailsGradlePluginCoordinate = resolver.resolve(artifactId).orElseThrow(() -> new LookupFailedException(artifactId));
         final ApplicationType applicationType = generatorContext.getApplicationType();
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.grails")
-                .lookupArtifactId("grails-gradle-plugin")
+                .artifactId("grails-gradle-plugin")
                 .buildSrc());
+
+        String grailsGradlePluginVersion = VersionInfo.getBomVersion("grails-gradle-plugin");
+
         if (applicationType == ApplicationType.PLUGIN || applicationType == ApplicationType.WEB_PLUGIN) {
-            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-plugin").version(grailsGradlePluginCoordinate.getVersion()).useApplyPlugin(true).build());
+            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-plugin").useApplyPlugin(true).build());
         }
         if (generatorContext.getFeature(GrailsWeb.class).isPresent()) {
-            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-web").version(grailsGradlePluginCoordinate.getVersion()).useApplyPlugin(true).build());
+            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-web").useApplyPlugin(true).build());
         }
         if (generatorContext.getFeature(GrailsGsp.class).isPresent()) {
-            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-gsp").version(grailsGradlePluginCoordinate.getVersion()).useApplyPlugin(true).build());
+            generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-gsp").useApplyPlugin(true).build());
         }
-        generatorContext.getBuildProperties().put("grailsGradlePluginVersion", grailsGradlePluginCoordinate.getVersion());
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsGradlePlugin.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsGradlePlugin.java
@@ -26,7 +26,6 @@ import org.grails.forge.feature.Feature;
 import org.grails.forge.feature.view.GrailsGsp;
 import org.grails.forge.feature.web.GrailsWeb;
 import org.grails.forge.options.Options;
-import org.grails.forge.util.VersionInfo;
 
 import java.util.Set;
 
@@ -66,8 +65,6 @@ class GrailsGradlePlugin implements DefaultFeature {
                 .groupId("org.grails")
                 .artifactId("grails-gradle-plugin")
                 .buildSrc());
-
-        String grailsGradlePluginVersion = VersionInfo.getBomVersion("grails-gradle-plugin");
 
         if (applicationType == ApplicationType.PLUGIN || applicationType == ApplicationType.WEB_PLUGIN) {
             generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.grails.grails-plugin").useApplyPlugin(true).build());

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsWebConsole.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsWebConsole.java
@@ -51,7 +51,7 @@ public class GrailsWebConsole implements Feature {
     public void apply(GeneratorContext generatorContext) {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
-                .lookupArtifactId("grails-console")
+                .artifactId("grails-console")
                 .runtimeOnly());
 
         final Map<String, Object> config = generatorContext.getConfiguration();

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
@@ -53,12 +53,12 @@ public class DatabaseMigrationPlugin implements MigrationFeature {
         final String srcDirPath = getSrcDirPath();
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
-                .lookupArtifactId("database-migration")
+                .artifactId("database-migration")
                 .buildSrc()
                 .extension(new RockerWritable(dbMigrationGradle.template(srcDirPath))));
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
-                .lookupArtifactId("database-migration")
+                .artifactId("database-migration")
                 .implementation());
     }
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/other/HibernateValidator.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/other/HibernateValidator.java
@@ -48,8 +48,8 @@ public class HibernateValidator implements Feature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         generatorContext.addDependency(Dependency.builder()
-                .groupId("org.hibernate")
-                .lookupArtifactId("hibernate-validator")
+                .groupId("org.hibernate.validator")
+                .artifactId("hibernate-validator")
                 .implementation());
     }
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/test/Junit.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/test/Junit.java
@@ -51,7 +51,7 @@ public class Junit implements TestFeature, DefaultFeature {
     public void doApply(GeneratorContext generatorContext) {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.junit.jupiter")
-                .lookupArtifactId("junit-jupiter")
+                .artifactId("junit-jupiter")
                 .testImplementation());
     }
 

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/ViewJson.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/ViewJson.java
@@ -74,7 +74,7 @@ public class ViewJson extends GrailsViews implements DefaultFeature {
 
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
-                .lookupArtifactId("views-gradle")
+                .artifactId("views-gradle")
                 .buildSrc());
 
         generatorContext.addBuildPlugin(GradlePlugin.builder()

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/view/markup/ViewMarkup.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/view/markup/ViewMarkup.java
@@ -70,7 +70,7 @@ public class ViewMarkup extends GrailsViews implements Feature {
 
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
-                .lookupArtifactId("views-gradle")
+                .artifactId("views-gradle")
                 .buildSrc());
 
         generatorContext.addBuildPlugin(GradlePlugin.builder()

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -13,56 +13,23 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.grails</groupId>
-            <artifactId>grails-gradle-plugin</artifactId>
-            <version>7.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.grails.plugins</groupId>
-            <artifactId>hibernate5</artifactId>
-            <version>9.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.grails.plugins</groupId>
-            <artifactId>cache</artifactId>
-            <version>8.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
+            <!-- Last released Feb 24, 2021 -->
             <groupId>org.grails.plugins</groupId>
             <artifactId>cache-ehcache</artifactId>
             <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.grails.plugins</groupId>
-            <artifactId>database-migration</artifactId>
-            <version>6.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.grails.plugins</groupId>
             <artifactId>quartz</artifactId>
-            <version>3.0.0</version>
+            <version>4.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.asciidoctor.jvm.convert</groupId>
             <artifactId>asciidoctor-gradle-jvm</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.3</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>7.0.5.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver-sync</artifactId>
-            <version>4.11.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.grails.plugins</groupId>
-            <artifactId>views-gradle</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
+            <!-- Last released Oct 17, 2022 -->
             <groupId>org.grails.plugins</groupId>
             <artifactId>embedded-mongodb</artifactId>
             <version>2.0.1</version>
@@ -70,12 +37,7 @@
         <dependency>
             <groupId>com.github.johnrengelman.shadow</groupId>
             <artifactId>shadow</artifactId>
-            <version>7.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.grails.plugins</groupId>
-            <artifactId>grails-console</artifactId>
-            <version>2.1.1</version>
+            <version>8.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.erdi</groupId>
@@ -85,17 +47,7 @@
         <dependency>
             <groupId>org.zeroturnaround</groupId>
             <artifactId>gradle-jrebel-plugin</artifactId>
-            <version>1.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.bertramlabs.plugins</groupId>
-            <artifactId>asset-pipeline-gradle</artifactId>
-            <version>5.0.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>io.micronaut</groupId>

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.asciidoctor.jvm.convert</groupId>
             <artifactId>asciidoctor-gradle-jvm</artifactId>
-            <version>4.0.3</version>
+            <version>4.0.4</version>
         </dependency>
         <dependency>
             <!-- Last released Oct 17, 2022 -->

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/asciidoctor/AsciidoctorSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/asciidoctor/AsciidoctorSpec.groovy
@@ -24,7 +24,7 @@ class AsciidoctorSpec extends ApplicationContextSpec implements CommandOutputFix
         final def buildGradle = output["build.gradle"]
 
         expect:
-        buildGradle.contains("id \"org.asciidoctor.jvm.convert\" version \"4.0.1\"")
+        buildGradle.contains("id \"org.asciidoctor.jvm.convert\"")
         buildGradle.contains("apply from: \"gradle/asciidoc.gradle\"")
     }
 
@@ -35,10 +35,10 @@ class AsciidoctorSpec extends ApplicationContextSpec implements CommandOutputFix
 
         expect:
         asciidocGradle.contains("""asciidoctorj {
-    version '2.1.0'
+    version '3.0.0'
     modules {
         diagram {
-            version '1.5.18'
+            version '2.3.1'
         }
     }
 

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -41,7 +41,7 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
                 .renderBuildSrc()
 
         then:
-        template.contains('implementation "org.grails.plugins:hibernate5:9.0.0-SNAPSHOT"')
+        template.contains('implementation "org.grails.plugins:hibernate5"')
     }
 
     void "test buildSrc is present for buildscript dependencies"() {
@@ -51,7 +51,7 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
 
         expect:
         buildGradle != null
-        buildGradle.contains("classpath \"org.grails.plugins:hibernate5:9.0.0-SNAPSHOT\"")
+        buildGradle.contains("classpath \"org.grails.plugins:hibernate5\"")
 
     }
 

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MongoSyncSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/MongoSyncSpec.groovy
@@ -33,7 +33,7 @@ class MongoSyncSpec extends ApplicationContextSpec implements CommandOutputFixtu
                 .render()
 
         then:
-        template.contains('implementation "org.mongodb:mongodb-driver-sync:4.11.3"')
+        template.contains('implementation "org.mongodb:mongodb-driver-sync"')
         template.contains('testImplementation "org.testcontainers:mongodb"')
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsGradlePluginSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsGradlePluginSpec.groovy
@@ -16,7 +16,6 @@ class GrailsGradlePluginSpec extends BeanContextSpec implements CommandOutputFix
         final String gradleProps = output["gradle.properties"]
 
         then:
-        gradleProps.contains("grailsGradlePluginVersion=7.0.0-SNAPSHOT")
         gradleProps.contains("grailsVersion=7.0.0-SNAPSHOT")
     }
 
@@ -26,7 +25,7 @@ class GrailsGradlePluginSpec extends BeanContextSpec implements CommandOutputFix
                 .renderBuildSrc()
 
         then:
-        template.contains('implementation "org.grails:grails-gradle-plugin:7.0.0-SNAPSHOT"')
+        template.contains('implementation "org.grails:grails-gradle-plugin"')
     }
 
     void "test buildSrc is present for buildscript dependencies"() {
@@ -36,7 +35,7 @@ class GrailsGradlePluginSpec extends BeanContextSpec implements CommandOutputFix
 
         expect:
         buildGradle != null
-        buildGradle.contains("classpath \"org.grails:grails-gradle-plugin:7.0.0-SNAPSHOT\"")
+        buildGradle.contains("classpath \"org.grails:grails-gradle-plugin\"")
 
     }
 

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsWebConsoleSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsWebConsoleSpec.groovy
@@ -22,7 +22,7 @@ class GrailsWebConsoleSpec extends BeanContextSpec {
                 .render()
 
         then:
-        template.contains("runtimeOnly \"org.grails.plugins:grails-console:2.1.1\"")
+        template.contains("runtimeOnly \"org.grails.plugins:grails-console\"")
     }
 
     void "test config"() {


### PR DESCRIPTION
- Use versions from grails-bom in additional locations
- add grail-bom to buildscript{} to pull in versions 
- put assetPipelineGradleVersion in gradle.properties 
- update dependency versions not provided by grails-bom