### PR TITLE
Revert "Merge pull request #503 from grails/exclude-org.graalvm-dependencies

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -72,18 +72,6 @@ repositories {
 
 @dependencies.template(applicationType, project, features, gradleBuild)
 
-@if(features.contains("asset-pipeline-grails")) {
-// exclude org.graalvm dependencies which are required by asset-pipeline-core
-// for bootRun but are not required in the deployed war/jar
-// see:  https://github.com/grails/grails-core/pull/13971
-tasks.named { it in ['bootWar', 'bootJar', 'war'] }.configureEach {
-    classpath = classpath.findAll {
-        !it.toString().contains('org.graalvm.')
-    }
-}
-
-}
-
 @if(features.contains("geb-with-webdriver-binaries")) {
 // geb-with-webdriver-binaries is limited to Gradle 8.6 with max JDK 21
 compileJava.options.release = @JdkVersion.valueOf(Math.min(features.javaVersion().majorVersion(), JdkVersion.JDK_21.majorVersion())).majorVersion()


### PR DESCRIPTION
This reverts commit 16f50d84241e759f1f9932b77fb38f5926b503ed

This is no longer needed with `asset-pipeline-gradle:5.0.6`

Confirmed that `bootJar`, `bootWar` and `war` tasks all produce the expected smaller file size with this code removed.

![image](https://github.com/user-attachments/assets/4d8a9ccf-274f-435e-9543-9f3203a0450c)
