### PR TITLE
Replace `tomcat-jdbc` with `HikariCP`

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
@@ -54,24 +54,6 @@ public interface DatabaseDriverConfigurationFeature extends Feature {
         config.put(ENVIRONMENTS_KEY + "." + PROD_ENVIRONMENT_KEY + "." + getDbCreateKey(), "none");
         Optional.ofNullable(dbFeature.getJdbcProdUrl()).ifPresent(url -> config.put(ENVIRONMENTS_KEY + "." + PROD_ENVIRONMENT_KEY + "." + getUrlKey(), url));
 
-        addProductionDataSourceProperties(config, "jmxEnabled", true);
-        addProductionDataSourceProperties(config, "initialSize", 5);
-        addProductionDataSourceProperties(config, "maxActive", 50);
-        addProductionDataSourceProperties(config, "minIdle", 5);
-        addProductionDataSourceProperties(config, "maxIdle", 25);
-        addProductionDataSourceProperties(config, "maxWait", 10000);
-        addProductionDataSourceProperties(config, "maxAge", 600000);
-        addProductionDataSourceProperties(config, "timeBetweenEvictionRunsMillis", 5000);
-        addProductionDataSourceProperties(config, "minEvictableIdleTimeMillis", 60000);
-        addProductionDataSourceProperties(config, "validationQuery", "SELECT 1");
-        addProductionDataSourceProperties(config, "validationQueryTimeout", 3);
-        addProductionDataSourceProperties(config, "validationInterval", 15000);
-        addProductionDataSourceProperties(config, "testOnBorrow", true);
-        addProductionDataSourceProperties(config, "testWhileIdle", true);
-        addProductionDataSourceProperties(config, "testOnReturn", false);
-        addProductionDataSourceProperties(config, "jdbcInterceptors", "ConnectionState");
-        addProductionDataSourceProperties(config, "defaultTransactionIsolation", 2);
-
         final Map<String, Object> additionalConfig = dbFeature.getAdditionalConfig();
         if (!additionalConfig.isEmpty()) {
             config.putAll(additionalConfig);

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/database/HibernateGorm.java
@@ -88,8 +88,8 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
                 .artifactId("hibernate5")
                 .implementation());
         generatorContext.addDependency(Dependency.builder()
-                .groupId("org.apache.tomcat")
-                .artifactId("tomcat-jdbc")
+                .groupId("com.zaxxer")
+                .artifactId("HikariCP")
                 .runtimeOnly());
     }
 

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/HibernateGormSpec.groovy
@@ -30,8 +30,8 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
 
         then:
         template.contains('implementation "org.grails.plugins:hibernate5"')
-        template.contains("runtimeOnly \"org.apache.tomcat:tomcat-jdbc\"")
-        template.contains("runtimeOnly \"com.h2database:h2\"")
+        template.contains('runtimeOnly "com.zaxxer:HikariCP"')
+        template.contains('runtimeOnly "com.h2database:h2"')
     }
 
     void "test dependencies are present for buildSrc"() {
@@ -81,23 +81,5 @@ class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputF
         config.environments.development.dataSource.url == 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
         config.environments.test.dataSource.url == 'jdbc:h2:mem:testDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
         config.environments.production.dataSource.url == 'jdbc:h2:./prodDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
-
-        config.environments.production.dataSource.properties.jmxEnabled == true
-        config.environments.production.dataSource.properties.initialSize == 5
-        config.environments.production.dataSource.properties.maxActive == 50
-        config.environments.production.dataSource.properties.minIdle == 5
-        config.environments.production.dataSource.properties.maxIdle == 25
-        config.environments.production.dataSource.properties.maxWait == 10000
-        config.environments.production.dataSource.properties.maxAge == 600000
-        config.environments.production.dataSource.properties.timeBetweenEvictionRunsMillis == 5000
-        config.environments.production.dataSource.properties.minEvictableIdleTimeMillis == 60000
-        config.environments.production.dataSource.properties.validationQuery == "SELECT 1"
-        config.environments.production.dataSource.properties.validationQueryTimeout == 3
-        config.environments.production.dataSource.properties.validationInterval == 15000
-        config.environments.production.dataSource.properties.testOnBorrow == true
-        config.environments.production.dataSource.properties.testWhileIdle == true
-        config.environments.production.dataSource.properties.testOnReturn == false
-        config.environments.production.dataSource.properties.jdbcInterceptors == "ConnectionState"
-        config.environments.production.dataSource.properties.defaultTransactionIsolation == 2
     }
 }


### PR DESCRIPTION
In accordance with the decision in the Grails Stewards Meeting 2024-10-10, this PR
switches the default JDBC connection pool in Grails 7 applications from `tomcat-jdbc` to `HikariCP`.

Spring HikariCP configuration Properties: https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.data.spring.datasource.hikari