### PR TITLE
Update maven artifactid from grails-console to grails-web-console

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsWebConsole.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsWebConsole.java
@@ -51,7 +51,7 @@ public class GrailsWebConsole implements Feature {
     public void apply(GeneratorContext generatorContext) {
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.grails.plugins")
-                .artifactId("grails-console")
+                .lookupArtifactId("grails-web-console")
                 .runtimeOnly());
 
         final Map<String, Object> config = generatorContext.getConfiguration();

--- a/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge-core/src/main/resources/pom.xml
@@ -59,5 +59,10 @@
             <artifactId>micronaut-serde-jackson</artifactId>
             <version>2.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.grails.plugins</groupId>
+            <artifactId>grails-web-console</artifactId>
+            <version>7.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsWebConsoleSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsWebConsoleSpec.groovy
@@ -22,7 +22,7 @@ class GrailsWebConsoleSpec extends BeanContextSpec {
                 .render()
 
         then:
-        template.contains("runtimeOnly \"org.grails.plugins:grails-console\"")
+        template.contains("runtimeOnly \"org.grails.plugins:grails-web-console")
     }
 
     void "test config"() {


### PR DESCRIPTION
https://github.com/grails/grails-forge/blob/0684bcdadd2617f05911c07af57d60ef15dec37e/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsWebConsole.java#L51-L55

`grails-console` should be `grails-web-console`

`grails-web-console` is not currently in grails-bom, add it to pom.xml and reference it from there instead