### PR TITLE
Revert "chore(deps): update dependency macos to v14"

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -83,7 +83,7 @@ jobs:
           path: grails-linux-amd64-snapshot.zip
   macos:
     name: "Build OS X Intel Native CLI"
-    runs-on: macos-14
+    runs-on: macos-13
     needs: build
     steps:
       - name: "📥 Checkout the repository"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           asset_content_type: application/zip
   macos:
     name: "Release OS X Intel Native CLI"
-    runs-on: macos-14
+    runs-on: macos-13
     needs: build
     steps:
       - name: "📥 Checkout repository"


### PR DESCRIPTION
This reverts commit 8563072c360092e3f2e127a3201d8a4843c9bc9e.

renovate[bot]
had auto committed a number of things and this is another one that bit us. That was disabled a few weeks back.