### PR TITLE
grails-shell-cli requires jansi 1.18 max, forge was providing 2.4.1 in combined grails-cli

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,8 @@ gradleSdkvendorPluginVersion=3.0.0
 groovyVersion=3.0.24
 jacksonDatabindVersion=2.18.3
 jakartaInjectVersion=1.0.5
-jansiVersion=2.4.1
+#match jansiVersion from grails-core
+jansiVersion=1.18
 javaDiffUtils=4.15
 jgitVersion=6.10.0.202406032230-r
 logbackClassicVersion=1.5.17


### PR DESCRIPTION
The combined grails-shell jar had jansi 2.4.1 which will not work with grails-shell-cli on windows

this fixes grails-cli and grails-wrapper

1.18 works for grails-shell-cli and grails-forge-cli

Fixes:  `Exception: java.lang.NoSuchMethodError thrown from the UncaughtExceptionHandler in thread "main"` which was occurring on: 

https://github.com/apache/grails-core/blob/f6e238c41e2800a9331108971807991711bfb369/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java#L370-L377

https://github.com/apache/grails-core/issues/13752 - details on grails-shell-cli current limitation and rewrite scope