### PR TITLE
Add missing grails-app directories

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsBase.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsBase.java
@@ -84,5 +84,12 @@ public class GrailsBase implements DefaultFeature {
         generatorContext.addTemplate("src/main/groovy", new URLTemplate("src/main/groovy/.gitkeep", classLoader.getResource(".gitkeep")));
         generatorContext.addTemplate("src/test/groovy", new URLTemplate("src/test/groovy/.gitkeep", classLoader.getResource(".gitkeep")));
         generatorContext.addTemplate("src/integration-test/groovy", new URLTemplate("src/integration-test/groovy/.gitkeep", classLoader.getResource(".gitkeep")));
+
+        generatorContext.addTemplate("grails-app/services", new URLTemplate("grails-app/services/.gitkeep", classLoader.getResource(".gitkeep")));
+        generatorContext.addTemplate("grails-app/domain", new URLTemplate("grails-app/domain/.gitkeep", classLoader.getResource(".gitkeep")));
+
+        if(generatorContext.getApplicationType() != ApplicationType.REST_API) {
+            generatorContext.addTemplate("grails-app/taglib", new URLTemplate("grails-app/taglib/.gitkeep", classLoader.getResource(".gitkeep")));
+        }
     }
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
@@ -20,6 +20,7 @@ import org.grails.forge.application.generator.GeneratorContext;
 import org.grails.forge.build.dependencies.Dependency;
 import org.grails.forge.feature.migration.templates.dbMigrationGradle;
 import org.grails.forge.template.RockerWritable;
+import org.grails.forge.template.URLTemplate;
 
 @Singleton
 public class DatabaseMigrationPlugin implements MigrationFeature {
@@ -60,6 +61,9 @@ public class DatabaseMigrationPlugin implements MigrationFeature {
                 .groupId("org.apache.grails")
                 .artifactId("grails-data-hibernate5-dbmigration")
                 .implementation());
+
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        generatorContext.addTemplate(srcDirPath, new URLTemplate(srcDirPath + "/.gitkeep", classLoader.getResource(".gitkeep")));
     }
 
     private String getSrcDirPath() {

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsBaseSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/grails/GrailsBaseSpec.groovy
@@ -25,6 +25,7 @@ import org.grails.forge.fixture.CommandOutputFixture
 import org.grails.forge.options.JdkVersion
 import org.grails.forge.options.Options
 import org.grails.forge.options.TestFramework
+import spock.lang.Unroll
 
 class GrailsBaseSpec extends BeanContextSpec implements CommandOutputFixture {
 
@@ -48,5 +49,35 @@ class GrailsBaseSpec extends BeanContextSpec implements CommandOutputFixture {
         output.containsKey("src/main/groovy/.gitkeep")
         output.containsKey("src/test/groovy/.gitkeep")
         output.containsKey("src/integration-test/groovy/.gitkeep")
+    }
+
+    @Unroll
+    void "test domain, services and taglib directories are present for ApplicationTypes other than REST_API"() {
+        when:
+        final def output = generate(applicationType, new Options(TestFramework.SPOCK))
+
+        then:
+
+        output.containsKey("grails-app/services/.gitkeep")
+        output.containsKey("grails-app/domain/.gitkeep")
+        output.containsKey("grails-app/taglib/.gitkeep")
+
+        where:
+        applicationType << ApplicationType.values() - ApplicationType.REST_API
+    }
+
+    @Unroll
+    void "test domain and services directories are present for ApplicationType.REST_API"() {
+        when:
+        final def output = generate(applicationType, new Options(TestFramework.SPOCK))
+
+        then:
+
+        output.containsKey("grails-app/services/.gitkeep")
+        output.containsKey("grails-app/domain/.gitkeep")
+        !output.containsKey("grails-app/taglib/.gitkeep")
+
+        where:
+        applicationType << [ApplicationType.REST_API]
     }
 }

--- a/grails-forge-core/src/test/groovy/org/grails/forge/feature/migration/DatabaseMigrationPluginSpec.groovy
+++ b/grails-forge-core/src/test/groovy/org/grails/forge/feature/migration/DatabaseMigrationPluginSpec.groovy
@@ -1,0 +1,74 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.grails.forge.feature.migration
+
+import org.grails.forge.ApplicationContextSpec
+import org.grails.forge.BuildBuilder
+import org.grails.forge.application.ApplicationType
+import org.grails.forge.fixture.CommandOutputFixture
+import org.grails.forge.options.Options
+import org.grails.forge.options.TestFramework
+import spock.lang.Unroll
+
+class DatabaseMigrationPluginSpec extends ApplicationContextSpec implements CommandOutputFixture{
+
+    void "test dependencies are present for gradle"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["database-migration"])
+                .render()
+
+        then:
+        template.contains('classpath "org.apache.grails:grails-data-hibernate5-dbmigration"')
+        template.contains('implementation "org.apache.grails:grails-data-hibernate5-dbmigration"')
+    }
+
+    void "test dependencies are present for buildSrc"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["database-migration"])
+                .renderBuildSrc()
+
+        then:
+        template.contains('implementation "org.apache.grails:grails-data-hibernate5-dbmigration"')
+    }
+
+    void "test dependencies are present for buildscript "() {
+        given:
+        final def output = generate(ApplicationType.WEB, new Options(TestFramework.SPOCK), ['database-migration'])
+        final def buildGradle = output["build.gradle"]
+
+        expect:
+        buildGradle != null
+        buildGradle.contains('classpath "org.apache.grails:grails-data-hibernate5-dbmigration"')
+    }
+
+    @Unroll
+    void "test migrations directory is present"() {
+        when:
+        final def output = generate(applicationType, new Options(TestFramework.SPOCK), ['database-migration'])
+
+        then:
+        output.containsKey("grails-app/migrations/.gitkeep")
+
+        where:
+        applicationType << ApplicationType.values()
+    }
+}


### PR DESCRIPTION
Ensures the following directories exist in the generated project, where appropriate, based on the application type and features selected.  Uses a `.gitignore` file in each directory.

grails-app/services
grails-app/domain
grails-app/taglib
grails-app/migrations