### PR TITLE
fix distribution to be compatible with sdkman

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -55,7 +55,7 @@ jobs:
           cp grails-cli/build/distributions/apache-grails-*.zip cli.zip
           unzip cli -d tmp1
           mv tmp1/apache-grails-* tmp1/cli
-          ./tmp1/cli/grails --version
+          ./tmp1/cli/bin/grails --version
       - name: "📤 Upload CLI Zip to Workflow Summary Page"
         if: ${{ matrix.java == '17' }}
         uses: actions/upload-artifact@v4

--- a/grails-cli/build.gradle
+++ b/grails-cli/build.gradle
@@ -143,11 +143,9 @@ forgeCliStartScripts.configure { CreateStartScripts t ->
     doLast {
         t.unixScript.text = t.unixScript.text
                 .replace('$APP_HOME/lib/', "\$APP_HOME/.grails/$grailsVersion/")
-                .replace('"${APP_HOME:-./}.."', '"${APP_HOME:-./}"')
 
         t.windowsScript.text = t.windowsScript.text
                 .replace('%APP_HOME%\\lib\\', "%APP_HOME%\\.grails\\$grailsVersion\\")
-                .replace('%DIRNAME%..', '%DIRNAME%')
     }
 }
 
@@ -156,26 +154,26 @@ project.extensions.getByType(DistributionContainer).configureEach {
     it.distributionClassifier.set('incubating-bin')
     it.contents {
         from(shadowJarTask) {
-            into ".grails/$grailsVersion"
+            into "bin/.grails/$grailsVersion"
         }
 
         from(cliStartScripts) {
-            into ''
+            into 'bin'
             fileMode = 0755
         }
 
         from(shellCliStartScripts) {
-            into ''
+            into 'bin'
             fileMode = 0755
         }
 
         from(forgeCliStartScripts) {
-            into ''
+            into 'bin'
             fileMode = 0755
         }
 
         from(rootProject.project(':grails-forge-cli').layout.buildDirectory.file('exploded/bin/grails_forge_cli_completion')) {
-            into ''
+            into 'bin'
             fileMode = 0755
         }
 


### PR DESCRIPTION
SDKMAN requires scripts to be in a bin directory.  This PR will place the scripts in a `bin` directory and leave the `.grails` directory in the same place as the scripts (matching the wrapper expectations).  We could technically let these be different and put the jars in a `lib` directory, but i thought it was best to mirror it's structure that wrapper creates to avoid confusion.