### PR TITLE
Unnest the snapshot zip uploaded to workflow results

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -61,7 +61,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'apache-grails-SNAPSHOT-incubating-bin.zip'
-          path: grails-cli/build/distributions/apache-grails-*.zip
+          include-hidden-files: true
+          path: tmp1/cli/**/*
           if-no-files-found: 'error'
   publish:
     if: github.repository_owner == 'apache' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')


### PR DESCRIPTION
Sample from workflow run:  https://github.com/apache/grails-forge/actions/runs/15619619727/artifacts/3317483009

vs

https://github.com/apache/grails-forge/actions/runs/15592561305/artifacts/3308182824