### PR TITLE
Load the root gradle.properties only for properties not already set in buildSrc

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -34,6 +34,7 @@ String grailsVersion
 
 // load the root gradle.properties only for properties not already set
 // (e.g., buildSrc/gradle.properties or by environment variables like ORG_GRADLE_PROJECT_grailsVersion=7.0.0)
+// https://github.com/gradle/gradle/issues/2534
 def props = new Properties()
 file('../gradle.properties').withInputStream { props.load(it) }
 props.each { key, val ->

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -32,6 +32,12 @@ GradleBuild gradleBuild,
 String grailsVersion
 )
 
+file('../gradle.properties').withInputStream {
+    Properties props = new Properties()
+    props.load(it)
+    project.ext.gradleProperties = props
+}
+
 repositories {
     mavenCentral()
     maven { url = 'https://repo.grails.org/grails/restricted' }
@@ -53,7 +59,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform("org.apache.grails:grails-gradle-bom:@VersionInfo.getGrailsVersion()")
+    implementation platform("org.apache.grails:grails-gradle-bom:$gradleProperties.grailsVersion")
 @for (GradleDependency dependency : gradleBuild.getBuildSrcDependencies()) {
     @dependency.toSnippet()
 }

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -32,7 +32,8 @@ GradleBuild gradleBuild,
 String grailsVersion
 )
 
-// load the root gradle.properties only for properties not already set (e.g., by environment variables like ORG_GRADLE_PROJECT_grailsVersion=7.0.0)
+// load the root gradle.properties only for properties not already set
+// (e.g., buildSrc/gradle.properties or by environment variables like ORG_GRADLE_PROJECT_grailsVersion=7.0.0)
 def props = new Properties()
 file('../gradle.properties').withInputStream { props.load(it) }
 props.each { key, val ->

--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -32,10 +32,13 @@ GradleBuild gradleBuild,
 String grailsVersion
 )
 
-file('../gradle.properties').withInputStream {
-    Properties props = new Properties()
-    props.load(it)
-    project.ext.gradleProperties = props
+// load the root gradle.properties only for properties not already set (e.g., by environment variables like ORG_GRADLE_PROJECT_grailsVersion=7.0.0)
+def props = new Properties()
+file('../gradle.properties').withInputStream { props.load(it) }
+props.each { key, val ->
+    if (!project.hasProperty(key)) {
+        project.ext."$key" = val
+    }
 }
 
 repositories {
@@ -59,7 +62,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform("org.apache.grails:grails-gradle-bom:$gradleProperties.grailsVersion")
+    implementation platform("org.apache.grails:grails-gradle-bom:$grailsVersion")
 @for (GradleDependency dependency : gradleBuild.getBuildSrcDependencies()) {
     @dependency.toSnippet()
 }


### PR DESCRIPTION
This matches the code from grails-core:  https://github.com/apache/grails-core/blob/7.0.x/buildSrc/build.gradle#L24-L28