### PR TITLE
grails-bom required in buildSrc/build.gradle for dependency versions

### DIFF
--- a/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -53,7 +53,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform("org.apache.grails:grails-gradle-bom:@VersionInfo.getGrailsVersion()")
+    implementation platform("org.apache.grails:grails-bom:@VersionInfo.getGrailsVersion()")
 @for (GradleDependency dependency : gradleBuild.getBuildSrcDependencies()) {
     @dependency.toSnippet()
 }


### PR DESCRIPTION
EX:
    implementation "org.apache.grails:grails-data-hibernate5"
    implementation "org.apache.grails:grails-data-hibernate5-dbmigration"

Versions for these plugins are included in grails-bom, but not in grails-gradle-bom.